### PR TITLE
Recognise application/xhtml+xml as HTML.

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -559,7 +559,11 @@ sub status {        my $self = shift; return $self->{status}; }
 sub ct {            my $self = shift; return $self->{ct}; }
 sub content_type {  my $self = shift; return $self->{ct}; }
 sub base {          my $self = shift; return $self->{base}; }
-sub is_html {       my $self = shift; return defined $self->ct && ($self->ct eq 'text/html'); }
+sub is_html {
+    my $self = shift; 
+    return defined $self->ct && 
+        ($self->ct eq 'text/html' || $self->ct eq 'application/xhtml+xml');
+}
 
 =head2 $mech->title()
 


### PR DESCRIPTION
This fixes Issue 162[1], making e.g. $mech->title() work for XHTML pages which
were returned with the application/xhtml+xml content type.

[1] http://code.google.com/p/www-mechanize/issues/detail?id=162
