### PR TITLE
WWW::Mechanize public autocheck method #2

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -185,6 +185,10 @@ L<WWW::Mechanize> is subclassed, such as for L<Test::WWW::Mechanize>
 or L<Test::WWW::Mechanize::Catalyst>, this may not be an appropriate
 default, so it's off.
 
+You can change the value later by calling:
+
+    $mech->autocheck( [0|1] );
+
 =item * C<< noproxy => [0|1] >>
 
 Turn off the automatic call to the L<LWP::UserAgent> C<env_proxy> function.
@@ -1988,6 +1992,32 @@ sub delete_header {
     }
 
     return;
+}
+
+
+=head2 $mech->autocheck(true/false)
+
+Change the autocheck state & return the current state.
+
+    $mech->autocheck(0); # don't fail on non HTTP 200 response
+    $mech->autocheck(1); # a non 200 HTTP response is an automatic failure.
+
+With no arguments, it will simply return the current autocheck state.
+
+    my $autocheck = $mech->autocheck();
+
+For more details, see the "autocheck" argument to WWW::Mechanize->new()
+
+=cut
+
+sub autocheck {
+    my $self = shift;
+
+    if (defined $_[0]) {
+        $self->{autocheck} = $_[0] ? 1 : 0;
+    }
+
+    return $self->{autocheck};
 }
 
 

--- a/t/autocheck.t
+++ b/t/autocheck.t
@@ -21,7 +21,7 @@ if ( @results ) {
 }
 my $bad_url = "http://$NONEXISTENT/";
 
-plan tests => 5;
+plan tests => 10;
 require_ok( 'WWW::Mechanize' );
 
 AUTOCHECK_OFF: {
@@ -39,4 +39,24 @@ AUTOCHECK_ON: {
     dies_ok {
         $mech->get( $bad_url );
     } qq{Couldn't fetch $bad_url, and died as a result};
+}
+
+AUTOCHECK_CHANGE: {
+    my $mech = WWW::Mechanize->new;
+    isa_ok( $mech, 'WWW::Mechanize' );
+
+    $mech->autocheck( 0 );
+
+    $mech->get( $bad_url );
+    ok( !$mech->success, qq{Didn't fetch $bad_url, but didn't die, either} );
+
+    $mech->autocheck( 1 );
+
+    dies_ok {
+        $mech->get( $bad_url );
+    } qq{Couldn't fetch $bad_url, and died as a result};
+
+    ok( $mech->autocheck(), 'autocheck getter correctly returns true' );
+    $mech->autocheck( 0 );
+    ok( !$mech->autocheck(), 'autocheck getter correctly returns false' );
 }


### PR DESCRIPTION
See http://groups.google.com/group/www-mechanize-users/browse_thread/thread/fb197de7418c775c

The minimum I can see that would be required:

- pod
- tests
- implementation

Feedback most welcome.

Murray.

Originally submitted as https://github.com/bestpractical/www-mechanize/pull/8/ this implements the suggested changes to a more conventional getter/setter api