### PR TITLE
Parse url (href attribute) for js window.open

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -2707,6 +2707,9 @@ sub _link_from_token {
         if ( $onClick && ($onClick =~ /^window\.open\(\s*'([^']+)'/) ) {
             $url = $1;
         }
+        elsif( $url && $url =~ /^javascript\:\s*(?:void\(\s*)?window\.open\(\s*'([^']+)'/s ){
+            $url = $1;
+        }
     } # a
 
     # Of the tags we extract from, only 'AREA' has an alt tag

--- a/t/find_link.html
+++ b/t/find_link.html
@@ -36,6 +36,7 @@
         <A HREF="http://nowhere.org/" Name="Here">NoWhere</A>
         <A HREF="http://nowhere.org/padded" Name=" Here "> NoWhere </A>
         <A HREF="blongo.html">Blongo!</A>
+        <A HREF="javascript: window.open( 'http://www.yahoo.com/', 'new', 'width=400,height=200,resizable=yes');" onClick="return confirm('Are your sure?');">Click Here</A>
     </body>
 </html>
 

--- a/t/find_link.t
+++ b/t/find_link.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-use Test::More tests => 62;
+use Test::More tests => 65;
 use URI::file;
 
 BEGIN {
@@ -149,3 +149,8 @@ ok( !defined $x, 'No match' );
 
 $x = $mech->find_link( url_abs_regex => qr[t/blongo\.html$] );
 isa_ok( $x, 'WWW::Mechanize::Link' );
+
+$x = $mech->find_link( text_regex => qr/click/i);
+isa_ok( $x, 'WWW::Mechanize::Link' );
+is( $x->[0], 'http://www.yahoo.com/', 'Got js url link' );
+is( $x->url, 'http://www.yahoo.com/', 'Got js url link' );


### PR DESCRIPTION
sub _link_from_token checks the onclick attribute for a js window.open url. This same markup can be found in the href attribute as well, but is not currently checked. This diff adds a line of code to similarly parse the href attribute.