### PR TITLE
Correct Link to Github repo

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -2846,7 +2846,7 @@ __END__
 WWW::Mechanize is hosted at GitHub, though the bug tracker still
 lives at Google Code.
 
-Repository: L<https://github.com/bestpractical/www-mechanize/>.
+Repository: L<https://github.com/libwww-perl/WWW-Mechanize>.
 Bugs: L<http://code.google.com/p/www-mechanize/issues>.
 
 =head1 OTHER DOCUMENTATION


### PR DESCRIPTION
The old link is 404, the new one appears to be correct. 
