### PR TITLE
ensure /quit_server calls for full HTTP/1.1 keepalive compatibility

### DIFF
--- a/t/local/encoding.t
+++ b/t/local/encoding.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-use Test::More tests => 5;
+use Test::More tests => 6;
 use lib qw( t/local );
 use LocalServer;
 
@@ -20,3 +20,5 @@ my $response = $mech->get( $server->url . 'encoding/euc-jp' );
 ok( $mech->success, 'Fetched OK' );
 is( $response->content_charset(), 'EUC-JP', 'got encoding enc-jp' );
 
+$response = $mech->get( $server->url . 'quit_server' );
+ok( $mech->success, 'Quit OK' );

--- a/t/local/referer-server
+++ b/t/local/referer-server
@@ -10,11 +10,18 @@ my $lhurl = URI::URL->new( $d->url );
 $lhurl->host( "localhost" );
 print $lhurl->as_string, "\n";
 
-$counter = 5;
+$counter = 6;
 while ($counter-- and my $c = $d->accept) {
     while (my $r = $c->get_request) {
-        my $ref = $r->headers->referer || "";
-        $c->send_response(HTTP::Response->new(200, "OK", undef, "Referer: '$ref'"));
+        my $location = ($r->uri->path || "/");
+        if ($location eq '/quit_server') {
+            $c->send_response(HTTP::Response->new(200, "OK", [Connection => 'close'], "quit"));
+            $counter = 0;
+            last;
+        } else {
+            my $ref = $r->headers->referer || "";
+            $c->send_response(HTTP::Response->new(200, "OK", undef, "Referer: '$ref'"));
+        }
     }
     $c->close;
     undef($c);

--- a/t/local/referer.t
+++ b/t/local/referer.t
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 use FindBin;
 
-use Test::More tests => 13;
+use Test::More tests => 14;
 
 BEGIN {
     use lib 't';
@@ -60,6 +60,9 @@ SKIP: {
     $agent->get( $url );
     is($agent->status, 200, 'Got fourth page') or diag $agent->res->message;
     is($agent->content, "Referer: '$ref'", 'Custom referer can be set');
+
+    $agent->get( $url . 'quit_server' );
+    ok( $agent->success, 'Quit OK' );
 };
 
 SKIP: {


### PR DESCRIPTION
The `t/local/encoding.t` & `t/local/referer.t` tests are _potentially_ deadlockable:

```
PERL5OPT=-MLWP::Protocol::Net::Curl=http_version,2 prove -lv t/local/encoding.t t/local/referer.t
```

Here, the testing server waits for the client to close connection, and vice-versa. The client _could_ be forced to use a non-keepalive connection, which solves the deadlock:

```
PERL5OPT=-MLWP::Protocol::Net::Curl=http_version,1 prove -lv t/local/encoding.t t/local/referer.t
```

Both tests could also include an explicit `undef $agent`. The attached code uses the already-available `/quit_server` URI to do the things in a safest way.
