### PR TITLE
v1.80 - Added form_action($action) to look up forms by regex containing ...

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,12 @@ Mech now has its own mailing list at Google Groups:
 http://groups.google.com/group/www-mechanize-users
 
 
+1.80        Mon Oct 28 08:21:17 EDT 2013
+========================================
+[ENHANCEMENTS]
+- Added form_action($action) to look up forms by regex matching $action.
+
+
 1.73        2013-08-24
 ========================================
 [TESTS]

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -6,11 +6,11 @@ WWW::Mechanize - Handy web browsing in a Perl object
 
 =head1 VERSION
 
-Version 1.73
+Version 1.80
 
 =cut
 
-our $VERSION = '1.73';
+our $VERSION = '1.80';
 
 =head1 SYNOPSIS
 
@@ -1301,6 +1301,37 @@ sub form_number {
     if ( $forms->[$form-1] ) {
         $self->{current_form} = $forms->[$form-1];
         return $self->{current_form};
+    }
+
+    return;
+}
+
+=head2 $mech->form_action( $action )
+
+Selects a form by action, using a regex containing $action.
+If there is more than one form on the page matching that action,
+then the first one is used, and a warning is generated.
+
+If it is found, the form is returned as an L<HTML::Form> object and
+set internally for later use with Mech's form methods such as
+C<L</field()>> and C<L</click()>>.
+
+Returns undef if no form is found.
+
+=cut
+
+sub form_action {
+    my ($self, $action) = @_;
+
+    my $temp;
+    my @matches = grep {defined($temp = $_->action) and ($temp =~ m/$action/msx) } $self->forms;
+
+    my $nmatches = @matches;
+    if ( $nmatches > 0 ) {
+        if ( $nmatches > 1 ) {
+            $self->warn( "There are $nmatches forms with action matching $action.  The first one was used." )
+        }
+        return $self->{current_form} = $matches[0];
     }
 
     return;

--- a/t/local/failure.t
+++ b/t/local/failure.t
@@ -40,7 +40,7 @@ GOOD_PAGE: {
     my @links = $mech->links;
     is( scalar @links, 10, '10 links, please' );
     my @forms = $mech->forms;
-    is( scalar @forms, 2, 'Two form' );
+    is( scalar @forms, 3, 'Many forms' );
 }
 
 BAD_PAGE: {

--- a/t/local/form.t
+++ b/t/local/form.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-use Test::More tests => 13;
+use Test::More tests => 18;
 
 use lib 't/local';
 use LocalServer;
@@ -19,20 +19,37 @@ my $mech = WWW::Mechanize->new();
 isa_ok( $mech, 'WWW::Mechanize' ) or die;
 $mech->quiet(1);
 $mech->get($server->url);
-ok( $mech->success, 'Got a page' ) or die;
-is( $mech->uri, $server->url, 'Got page' );
+ok( $mech->success, 'got a page' ) or die;
+is( $mech->uri, $server->url, 'got correct page' );
 
 my $form_number_1 = $mech->form_number(1);
-isa_ok( $form_number_1, 'HTML::Form', 'Can select the first form');
-is( $mech->current_form(), $mech->{forms}->[0], 'Set the form attribute' );
+isa_ok( $form_number_1, 'HTML::Form', 'form_number - can select the first form');
+is( $mech->current_form(), $mech->{forms}->[0], 'form_number - set the form attribute' );
 
-ok( !$mech->form_number(99), 'cannot select the 99th form');
-is( $mech->current_form(), $mech->{forms}->[0], 'Form is still set to 1' );
+ok( !$mech->form_number(99), 'form_number - cannot select the 99th form');
+is( $mech->current_form(), $mech->{forms}->[0], 'form_number - form is still set to 1' );
 
 my $form_name_f = $mech->form_name('f');
-isa_ok( $form_name_f, 'HTML::Form', 'Can select the form' );
-ok( !$mech->form_name('bargle-snark'), 'cannot select non-existent form' );
+isa_ok( $form_name_f, 'HTML::Form', 'form_name - can select the form' );
+ok( !$mech->form_name('bargle-snark'), 'form_name - cannot select non-existent form' );
 
 my $form_id_pounder = $mech->form_id('pounder');
-isa_ok( $form_id_pounder, 'HTML::Form', 'Can select the form' );
-ok( !$mech->form_id('bargle-snark'), 'cannot select non-existent form' );
+isa_ok( $form_id_pounder, 'HTML::Form', 'form_id - can select the form' );
+ok( !$mech->form_id('bargle-snark'), 'form_id - cannot select non-existent form' );
+
+my $form_id_searchbox = $mech->form_action('google-cli');
+isa_ok( $form_id_searchbox, 'HTML::Form', 'form_action - can select the form' );
+ok( !$mech->form_action('bargle-snark'), 'form_action - cannot select non-existent form' );
+my $form;
+my $exception = '';
+eval {
+    $mech->quiet(0);
+    local *STDERR;
+    open STDERR, '>', \$exception;
+    $form = $mech->form_action('formsubmit');
+    close STDERR;
+};
+isa_ok( $form, 'HTML::Form', 'form_action - can select the form');
+cmp_ok($exception, 'ne', '', 'form_action - got multiple-matching-forms warning');
+like($exception, qr/with action matching/, 'form_action - got correct multiple-matching-forms warning');
+$mech->quiet(1);

--- a/t/local/log-server
+++ b/t/local/log-server
@@ -6,7 +6,7 @@ use CGI;
 use encoding 'iso-8859-1';
 use Getopt::Long;
 use vars qw($VERSION);
-$VERSION = '0.55';
+$VERSION = '0.56';
 
 $|++;
 
@@ -189,6 +189,9 @@ __DATA__
     <input type="file" name="upload" value="README" />
   </form>
   <form id="pounder" action="/formsubmit">
+    <input type="text" name="query" value="%s"/>
+  </form>
+  <form id="searchbox" action="/google-cli">
     <input type="text" name="query" value="%s"/>
   </form>
 </p>

--- a/tags
+++ b/tags
@@ -135,6 +135,7 @@ find_image	lib/WWW/Mechanize.pm	/^sub find_image {$/;"	s
 find_link	lib/WWW/Mechanize.pm	/^sub find_link {$/;"	s
 follow_link	lib/WWW/Mechanize.pm	/^sub follow_link {$/;"	s
 form_id	lib/WWW/Mechanize.pm	/^sub form_id {$/;"	s
+form_action	lib/WWW/Mechanize.pm	/^sub form_action {$/;"	s
 form_name	lib/WWW/Mechanize.pm	/^sub form_name {$/;"	s
 form_number	lib/WWW/Mechanize.pm	/^sub form_number {$/;"	s
 form_with_fields	lib/WWW/Mechanize.pm	/^sub form_with_fields {$/;"	s


### PR DESCRIPTION
...$action

1) Bumped version to v1.80.
2) Added form_action($action) to look up forms by a regex containing $action.
3) Modified t/local/log-server so we could test finding 1 form and finding
   many forms using form_action($action). Also bumped version to 0.56.
4) Added form_action($action) tests to t/local/form.t. Also modified the
   test outputs to clearly identify which form_*() is under test (and cleaned
   up some test outputs capitalization).
5) Modified Changes and tags for form_action($action).

I thought v1.80 was appropriate since I was adding to the API.
