### PR TITLE
Add a somewhat more descriptive error message when ->request is called w...

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -2302,6 +2302,9 @@ Returns an L<HTTP::Response> object.
 sub request {
     my $self = shift;
     my $request = shift;
+    
+    _die( '->request was called without a request parameter' )
+        unless $request;
 
     $request = $self->_modify_request( $request );
 

--- a/t/bad-request.t
+++ b/t/bad-request.t
@@ -1,0 +1,35 @@
+#!perl
+
+use warnings;
+use strict;
+use Test::More tests => 2;
+
+=head1 NAME
+
+bad-request.t
+
+=head1 SYNOPSIS
+
+Tests the detection of bad API usage.
+
+  ->request()
+
+Checks for behaviour of calls to C<< ->request() >> without the required
+parameter.
+
+=cut
+
+use WWW::Mechanize;
+
+my $mech = WWW::Mechanize->new();
+
+my $lives= eval {
+#line 1
+    $mech->request();
+    1
+};
+my $err= $@;
+ok !$lives, "->request wants at least one parameter";
+like $err, qr/->request was called without a request parameter/,
+    "We carp with a descriptive error message";
+


### PR DESCRIPTION
...ithout a parameter

This replaces the error message

  "Can't call method ->header on an undefined value"

somewhere deep in WWW::Mechanize with the error message

  '->request was called without a request parameter'

from the perspective of the caller instead.