### PR TITLE
 Document that form_id warns in addition to returning undef when a form cannot be found

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Revision history for WWW::Mechanize
 Mech now has its own mailing list at Google Groups:
 http://groups.google.com/group/www-mechanize-users
 
+- Document that form_id warns in addition to returning undef when a form cannot
+  be found.
+
 1.75        2015-06-03
 ========================================
 [OTHER CHANGES]

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -1346,7 +1346,8 @@ If it is found, the form is returned as an L<HTML::Form> object and
 set internally for later use with Mech's form methods such as
 C<L</field()>> and C<L</click()>>.
 
-Returns undef if no form is found.
+If no form is found it returns C<undef>.  This will also trigger a warning,
+unless C<quiet> is enabled.
 
 =cut
 


### PR DESCRIPTION
I was quite surprised today when a simple check to see if a form existed triggered a warning in my $work test suite.  I had checked the docs before using this method and there was not even a hint that I should expect a warn.  :)