### PR TITLE
unshare custom headers on ->clone

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -2258,6 +2258,7 @@ sub clone {
     my $clone = $self->SUPER::clone();
 
     $clone->cookie_jar( $self->cookie_jar );
+    $clone->{headers} = { %{$self->{headers}} };
 
     return $clone;
 }

--- a/t/clone.t
+++ b/t/clone.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-use Test::More tests => 5;
+use Test::More tests => 6;
 
 BEGIN {
     use_ok( 'WWW::Mechanize' );
@@ -30,4 +30,13 @@ COOKIE_SHARING: {
     my $new_cookies = $clone->cookie_jar->as_string;
 
     is( $old_cookies, $new_cookies, 'Adding cookies adds to both jars' );
+}
+
+HEADERS_NOT_SHARING: {
+    # headers should be independent
+    $clone->add_header(foo=>'bar');
+    ok(
+        not($mech->{headers}{foo}),
+        'Adding headers does not add to both agents',
+    );
 }


### PR DESCRIPTION
The documentation says that the headers (`add_header`, `delete_header`) are per-instance.

When cloning a mechanize object, the clone shares the headers hashref with the original object. This is quite probably wrong.

This commit fixes that (with test)