### PR TITLE
implemented ->form_with()

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ http://groups.google.com/group/www-mechanize-users
 
 {{$NEXT}}
 
+[ENHANCEMENTS]
+- Added form_with() method. (Martin Sluka)
+
 1.78      2016-08-08 09:18:59-04:00 America/Toronto
 ========================================
 [OTHER CHANGES]

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -1457,13 +1457,11 @@ sub form_with {
     my @forms = $self->forms or return;
     foreach my $attr ( keys %spec ) {
         @forms = grep {
-            my $actual_value = $_->attr($attr);
-            if ( defined( my $expected_value = $spec{$attr} ) ) {
-                defined $actual_value && $actual_value eq $expected_value;
-            }
-            else {
-                !defined $actual_value;
-            }
+            my $expected_value = $spec{$attr};
+            my $actual_value   = $_->attr($attr);
+            defined $expected_value
+              ? defined $actual_value && $actual_value eq $expected_value
+              : !defined $actual_value;
         } @forms or return;
     }
 

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -1456,13 +1456,7 @@ sub form_with {
 
     my @forms = $self->forms or return;
     foreach my $attr ( keys %spec ) {
-        @forms = grep {
-            my $expected_value = $spec{$attr};
-            my $actual_value   = $_->attr($attr);
-            defined $expected_value
-              ? defined $actual_value && $actual_value eq $expected_value
-              : !defined $actual_value;
-        } @forms or return;
+        @forms = grep _equal( $spec{$attr}, $_->attr($attr) ), @forms or return;
     }
     if ( @forms > 1 ) {    # Warn if several forms matched.
         # For ->form_with( method => 'POST', action => '', id => undef ) we get:
@@ -1495,6 +1489,15 @@ sub form_with {
 
     return $self->{current_form} = $forms[0];
 }
+
+# NOT an object method!
+# Expects two values and returns true only when either
+# both are defined and eq(ual) or when both are not defined.
+sub _equal {
+    my ( $x, $y ) = @_;
+    defined $x ? defined $y && $x eq $y : !defined $y;
+}
+
 
 =head1 FIELD METHODS
 

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -1464,9 +1464,7 @@ sub form_with {
               : !defined $actual_value;
         } @forms or return;
     }
-
     if ( @forms > 1 ) {    # Warn if several forms matched.
-
         # For ->form_with( method => 'POST', action => '', id => undef ) we get:
         # >>There are 2 forms with empty action and no id and method "POST".
         # The first one was used.<<
@@ -1480,11 +1478,11 @@ sub form_with {
                         unless ( defined $spec{$_} ) {    # case $attr => undef
                             qq{no $_};
                         }
-                        elsif ( length $spec{$_} ) {      # case $attr => $value
-                            qq{$_ "$spec{$_}"};
-                        }
-                        else {                            # case $attr=> ''
+                        elsif ( $spec{$_} eq '' ) {       # case $attr=> ''
                             qq{empty $_};
+                        }
+                        else {                            # case $attr => $value
+                            qq{$_ "$spec{$_}"};
                         }
                       }                # case $attr => undef
                       sort keys %spec  # sort keys to get deterministic messages

--- a/t/local/form.t
+++ b/t/local/form.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-use Test::More tests => 15;
+use Test::More tests => 19;
 
 use lib 't/local';
 use LocalServer;
@@ -13,7 +13,8 @@ BEGIN {
 my $server = LocalServer->spawn;
 isa_ok( $server, 'LocalServer' );
 
-my $mech = WWW::Mechanize->new();
+my @warnings;
+my $mech = WWW::Mechanize->new( onwarn => sub { push @warnings, @_ } );
 isa_ok( $mech, 'WWW::Mechanize' ) or die;
 $mech->quiet(1);
 $mech->get($server->url);
@@ -39,3 +40,15 @@ my $form_with = $mech->form_with( class => 'test', id => undef );
 isa_ok( $form_with, 'HTML::Form', 'Can select the form without id' );
 is( $mech->current_form, $form_number_1,
     'Form without id is now the current form' );
+
+is( scalar @warnings, 0, 'no warnings so far' );
+$mech->quiet(0);
+$form_with = $mech->form_with( class => 'test', foo => '', bar => undef );
+is( $form_with, $form_number_1, 'Can select form with ambiguous criteria' );
+is( scalar @warnings, 1, 'Got one warning' );
+is(
+    "@warnings",
+    'There are 2 forms with no bar and class "test"'
+      . ' and empty foo.  The first one was used.',
+    'Got expected warning'
+);

--- a/t/local/form.t
+++ b/t/local/form.t
@@ -1,6 +1,6 @@
 use warnings;
 use strict;
-use Test::More tests => 13;
+use Test::More tests => 15;
 
 use lib 't/local';
 use LocalServer;
@@ -34,3 +34,8 @@ ok( !$mech->form_name('bargle-snark'), 'cannot select non-existent form' );
 my $form_id_pounder = $mech->form_id('pounder');
 isa_ok( $form_id_pounder, 'HTML::Form', 'Can select the form' );
 ok( !$mech->form_id('bargle-snark'), 'cannot select non-existent form' );
+
+my $form_with = $mech->form_with( class => 'test', id => undef );
+isa_ok( $form_with, 'HTML::Form', 'Can select the form without id' );
+is( $mech->current_form, $form_number_1,
+    'Form without id is now the current form' );

--- a/t/local/log-server
+++ b/t/local/log-server
@@ -180,7 +180,7 @@ __DATA__
     <tr><td>B1</td><td>B2</td><td>B3</td></tr>
     <tr><td>C1</td><td>C2</td><td>C3</td></tr>
   </table>
-  <form name="f" action="/formsubmit" class="test">
+  <form name="f" action="/formsubmit" class="test" foo="">
     <input type="hidden" name="session" value="%s"/>
     <input type="text" name="query" value="%s"/>
     <input type="submit" name="submit" value="Go" id="0" />
@@ -189,7 +189,7 @@ __DATA__
     <input type="checkbox" name="cat" value="cat_baz" %s />
     <input type="file" name="upload" value="README" />
   </form>
-  <form id="pounder" action="/formsubmit" class="test">
+  <form id="pounder" action="/formsubmit" class="test" foo="">
     <input type="text" name="query" value="%s"/>
   </form>
 </p>

--- a/t/local/log-server
+++ b/t/local/log-server
@@ -180,7 +180,7 @@ __DATA__
     <tr><td>B1</td><td>B2</td><td>B3</td></tr>
     <tr><td>C1</td><td>C2</td><td>C3</td></tr>
   </table>
-  <form name="f" action="/formsubmit">
+  <form name="f" action="/formsubmit" class="test">
     <input type="hidden" name="session" value="%s"/>
     <input type="text" name="query" value="%s"/>
     <input type="submit" name="submit" value="Go" id="0" />
@@ -189,7 +189,7 @@ __DATA__
     <input type="checkbox" name="cat" value="cat_baz" %s />
     <input type="file" name="upload" value="README" />
   </form>
-  <form id="pounder" action="/formsubmit">
+  <form id="pounder" action="/formsubmit" class="test">
     <input type="text" name="query" value="%s"/>
   </form>
 </p>


### PR DESCRIPTION
Since my bank uses funny obfuscation techniques in their [online portal](https://www.sparkasse-nuernberg.de/) (changing names of and field names within forms upon each request), I needed a more flexible way to select forms.
I hope it is self-explanatory.