### PR TITLE
Add HTML::Form Strict Flag

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ Mech now has its own mailing list at Google Groups:
 http://groups.google.com/group/www-mechanize-users
 
 {{$NEXT}}
+[ENHANCEMENTS]
+- Added strict_forms flag to submit_form() which sets the HTML::Form strict flag (Gareth Tunley)
 
 1.81      2016-10-06 08:52:44-04:00 America/Toronto
 ========================================

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -2042,6 +2042,12 @@ Clicks on button I<button> (calls C<L</click()>>)
 
 Sets the x or y values for C<L</click()>>
 
+=item * C<< strict_forms => bool >>
+
+Sets the HTML::Form strict flag which causes form submission to croak if any of the passed
+fields don't exist on the page, and/or a value doesn't exist in a select element.
+By default HTML::Form defaults this value to false.
+
 =back
 
 If no form is selected, the first form found is used.
@@ -2061,7 +2067,7 @@ sub submit_form {
     my( $self, %args ) = @_;
 
     for ( keys %args ) {
-        if ( !/^(form_(number|name|fields|id)|(with_)?fields|button|x|y)$/ ) {
+        if ( !/^(form_(number|name|fields|id)|(with_)?fields|button|x|y|strict_forms)$/ ) {
             # XXX Why not die here?
             $self->warn( qq{Unknown submit_form parameter "$_"} );
         }
@@ -2127,6 +2133,12 @@ sub submit_form {
             die "More than one form satisfies all the criteria";
         }
         $self->{current_form} = $matched[0];
+    }
+
+    if (defined($args{strict_forms})) {
+        # Strict argument has been passed, set the flag as appropriate
+        # this must be done prior to attempting to set the fields
+        $self->current_form->strict($args{strict_forms});
     }
 
     $self->set_fields( %{$fields} ) if $fields;
@@ -2487,7 +2499,7 @@ Returns an L<HTTP::Response> object.
 sub request {
     my $self = shift;
     my $request = shift;
-    
+
     _die( '->request was called without a request parameter' )
         unless $request;
 

--- a/t/form_with_fields.t
+++ b/t/form_with_fields.t
@@ -146,3 +146,54 @@ ok( $mech->success, "Fetched $uri" ) or die q{Can't get test page};
         ' submit_form( with_fields => %data ) ',
     );
 }
+
+{
+    $mech->get($uri);
+    is(
+        exception {
+            $mech->submit_form(
+                form_name => '1st_form',
+                fields => {
+                    '1c' => 'madeup_field',
+                },
+            );
+        },
+        undef,
+        'submit_form with invalid field and without strict_forms option succeeds',
+    );
+}
+
+{
+    $mech->get($uri);
+    like(
+        exception {
+            $mech->submit_form(
+                form_name => '1st_form',
+                fields => {
+                    '1c' => 'madeup_field',
+                },
+                strict_forms => 1,
+            );
+        },
+        qr/^No such field '1c'/,
+        'submit_form with invalid field and strict_forms option fails',
+    );
+}
+
+{
+    $mech->get($uri);
+    is(
+        exception {
+            $mech->submit_form(
+                form_name => '1st_form',
+                fields => {
+                    '1a' => 'value1',
+                    '1b' => 'value2',
+                },
+                strict_forms => 1,
+            );
+        },
+        undef,
+        'submit_form with valid fields and strict_forms option succeeds',
+    );
+}


### PR DESCRIPTION
Sorry I completely screwed up the branch and had to delete it and start again.

Re-adding original description:

Add the strict flag as defined at:

https://metacpan.org/pod/HTML::Form#strict-bool

This is especially useful when combined with Test::WWW::Mechanize
to cause testing to bomb out if a form field or select value is
not present on the form.
