### PR TITLE
Print section titles if mech-dump --all is invoked. Fixes #35

### DIFF
--- a/bin/mech-dump
+++ b/bin/mech-dump
@@ -12,6 +12,7 @@ use Pod::Usage;
 use HTTP::Cookies;
 my @actions;
 my $absolute;
+my $all;
 
 my $user;
 my $pass;
@@ -26,7 +27,7 @@ GetOptions(
     forms           => sub { push( @actions, \&dump_forms ) },
     links           => sub { push( @actions, \&dump_links ) },
     images          => sub { push( @actions, \&dump_images ) },
-    all             => sub { push( @actions, \&dump_headers, \&dump_forms, \&dump_links, \&dump_images ) },
+    all             => sub { $all++; push( @actions, \&dump_headers, \&dump_forms, \&dump_links, \&dump_images ) },
     text            => sub { push( @actions, \&dump_text ) },
     absolute        => \$absolute,
     'agent=s'       => \$agent,
@@ -122,24 +123,28 @@ while ( my $action = shift @actions ) {
 
 sub dump_headers {
     my $mech = shift;
+    print "--> Headers:\n" if $all;
     $mech->dump_headers( undef );
     return;
 }
 
 sub dump_forms {
     my $mech = shift;
+    print "--> Forms:\n" if $all;
     $mech->dump_forms( undef, $absolute );
     return;
 }
 
 sub dump_links {
     my $mech = shift;
+    print "--> Links:\n" if $all;
     $mech->dump_links( undef, $absolute );
     return;
 }
 
 sub dump_images {
     my $mech = shift;
+    print "--> Images:\n" if $all;
     $mech->dump_images( undef, $absolute );
     return;
 }


### PR DESCRIPTION
Hi! Here's my 2 cents for [LWP hack night](http://www.olafalders.com/2017/03/28/preparing-for-lwp-hack-night/) ;)

I personally find `ucfirst` titles a bit more pleasing (comparing to an original suggestion from #35).
I've also added a prefix (`-->`), otherwise those titles could be confused with an empty-valued HTTP header.