### PR TITLE
fix broken internal POD link for update_html

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -656,7 +656,7 @@ sub title {
 Returns the content that the mech uses internally for the last page
 fetched. Ordinarily this is the same as
 C<< $mech->response()->decoded_content() >>,
-but this may differ for HTML documents if L</update_html> is
+but this may differ for HTML documents if L<< update_html|/$mech->update_html( $html ) >> is
 overloaded (in which case the value passed to the base-class
 implementation of same will be returned), and/or extra named arguments
 are passed to I<content()>:


### PR DESCRIPTION
The `update_html` link was broken in the metacpan pod (and likely other places) because the `=head2` of `update_html` contains arguments. I tested this locally with `pod2html lib/WWW/Mechanize.pm  | grep update_html`, but the output of that didn't produce a `name` attribute in the `<h2>` tag. The link `<a href="#mech--update_html-html">` it produced also looks different than on metacpan, but I think there renderer there is different. I _think_ it will fix the broken link, but I am not completely sure.