### PR TITLE
Issue #86: Improve t/credentials-api.t test

### DIFF
--- a/t/credentials-api.t
+++ b/t/credentials-api.t
@@ -18,6 +18,8 @@ my $uri   = URI->new( 'http://localhost' );
 my $realm = 'myrealm';
 
 my $ua    = LWP::UserAgent->new();
+$ua->credentials($uri, $realm, 'user', 'pass');
+
 my $mech1 = WWW::Mechanize->new();
 my $mech2 = WWW::Mechanize->new();
 my $mech3 = WWW::Mechanize->new();
@@ -25,8 +27,7 @@ my $mech3 = WWW::Mechanize->new();
 $mech1->credentials('mech1','mech1');
 $mech2->credentials('mech2','mech2');
 
-my @ua = $ua->credentials;
-isnt( "@ua", "mech2 mech2", 'LWP::UserAgent instance retains its old credentials' );
+is_deeply( [$ua->credentials($uri, $realm)], ['user', 'pass'], 'LWP::UserAgent instance retains its old credentials' );
 
 is_deeply( [$mech1->get_basic_credentials( $realm, $uri )], ['mech1', 'mech1'], 'First instance retains its credentials' );
 is_deeply( [$mech2->get_basic_credentials( $realm, $uri )], ['mech2', 'mech2'], 'Second instance retains its credentials' );


### PR DESCRIPTION
This test was trying to make sure if LWP's credentials are
unaffected by Mech credentials being set up. To do that, let's
set LWP credentials, and check if it's still the same afterwards

\#cpan-prc \#team-ziprecruiter