### PR TITLE
PRC: doc patch.  Submit only submits current form

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,7 +917,7 @@ the keys.
 
 ## $mech->submit()
 
-Submits the page, without specifying a button to click.  Actually,
+Submits the current form, without specifying a button to click.  Actually,
 no button is clicked at all.
 
 Returns an [HTTP::Response](https://metacpan.org/pod/HTTP::Response) object.

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -1981,7 +1981,7 @@ sub click_button {
 
 =head2 $mech->submit()
 
-Submits the page, without specifying a button to click.  Actually,
+Submits the current form, without specifying a button to click.  Actually,
 no button is clicked at all.
 
 Returns an L<HTTP::Response> object.


### PR DESCRIPTION
This addresses github issue #34.  Doc only patch.