### PR TITLE
use an explicit ipv4 address in this test, to avoid a hang (GH#31)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for WWW::Mechanize
 
 {{$NEXT}}
+    [FIXED]
+    - use 127.0.0.1 instead of 'localhost' in a test to avoid the test hanging
+      due to ipv6 issues (GH#31)
 
 1.84      2017-03-07 13:34:57-05:00 America/Toronto
 [ENHANCEMENTS]

--- a/t/local/LocalServer.pm
+++ b/t/local/LocalServer.pm
@@ -115,7 +115,7 @@ sub spawn {
 
   # What is this code supposed to fix?
   my $lhurl = URI::URL->new( $url );
-  $lhurl->host( 'localhost' );
+  $lhurl->host( '127.0.0.1' );
   $self->{_server_url} = $lhurl;
   
   $self->{_fh} = $server;


### PR DESCRIPTION
use an explicit ipv4 address in this test, to avoid a hang

This provides a workaround for issues: #31, #88, #98, #100, #101, #103, #226,
RT#63272, RT#106677, RT#117893.