### PR TITLE
    use an explicit ipv4 address in this test script too (as in v1.85…

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for WWW::Mechanize
 
 {{$NEXT}}
+    [FIXED]
+    - use 127.0.0.1 instead of 'localhost' in a test script to avoid the test
+      hanging due to ipv6 issues (GH#31, see also changes in 1.85)
 
 1.85      2017-06-28 22:06:00Z
 ========================================

--- a/t/local/referer-server
+++ b/t/local/referer-server
@@ -7,7 +7,7 @@ $|++;
 
 my $d = HTTP::Daemon->new or die;
 my $lhurl = URI::URL->new( $d->url );
-$lhurl->host( "localhost" );
+$lhurl->host( "127.0.0.1" );
 print $lhurl->as_string, "\n";
 
 $counter = 5;


### PR DESCRIPTION
…), to avoid a hang

    This provides a workaround for issues: #31, #88, #98, #100, #101, #103, #226,
    RT#63272, RT#106677, RT#117893.