### PR TITLE
Override _agent() method. Fixes #215

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -280,6 +280,9 @@ sub new {
     return $self;
 }
 
+# overriding LWP::UA's static method
+sub _agent { "WWW-Mechanize/$VERSION" }
+
 =head2 $mech->agent_alias( $alias )
 
 Sets the user agent string to the expanded version from a table of actual user strings.

--- a/t/new.t
+++ b/t/new.t
@@ -2,7 +2,7 @@
 
 use warnings;
 use strict;
-use Test::More tests => 14;
+use Test::More tests => 15;
 
 BEGIN {
     use_ok( 'WWW::Mechanize' );
@@ -28,6 +28,8 @@ NO_AGENT: {
 
     $m->agent( 'foo/bar v1.23' );
     is( $m->agent, 'foo/bar v1.23', 'Can set the agent' );
+
+    like( $m->_agent, qr/WWW-Mechanize/, '_agent() is static' );
 }
 
 USER_AGENT: {


### PR DESCRIPTION
Not sure this needs a doc patch -- it is omitted in the parent module after all...
Can still add it, if deemed necessary.