### PR TITLE
tick() now dies if checkbox is not found

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -1866,8 +1866,8 @@ sub tick {
         $index++;
     } # while
 
-    # got self far?  Didn't find anything
-    $self->warn( qq{No checkbox "$name" for value "$value" in form} );
+    # got this far?  Didn't find anything
+    $self->die( qq{No checkbox "$name" for value "$value" in form} );
 } # tick()
 
 =head2 $mech->untick($name, $value)

--- a/t/tick.t
+++ b/t/tick.t
@@ -2,7 +2,9 @@
 
 use warnings;
 use strict;
-use Test::More tests => 5;
+
+use Test::Fatal qw( exception );
+use Test::More;
 use URI::file;
 
 delete @ENV{qw(PATH IFS CDPATH ENV BASH_ENV)};  # Placates taint-unsafe Cwd.pm in 5.6.1
@@ -35,3 +37,10 @@ EOT
 
 is( $reqstring, $wanted, 'Proper posting' );
 
+like(
+    exception { $mech->tick( 'not_there', 1 ) },
+    qr{No checkbox "not_there" for value "1" in form},
+    'dies if checkbox not found'
+);
+
+done_testing();


### PR DESCRIPTION
This behaviour is now in line with the documentation.

Fixes #239 