### PR TITLE
Fix the handling of fields of type "file"

### DIFF
--- a/t/file_upload.html
+++ b/t/file_upload.html
@@ -1,0 +1,4 @@
+<form method="post" enctype="multipart/form-data">
+  <input type="file" name="document">
+  <input type="submit">
+</form>

--- a/t/file_upload.t
+++ b/t/file_upload.t
@@ -1,0 +1,54 @@
+use strict;
+use warnings;
+use Test::More;
+use WWW::Mechanize;
+use URI::file;
+
+my $file     = 't/file_upload.html';
+my $filename = 'the_file_upload.html';
+my $mc = WWW::Mechanize->new;
+my $uri = URI::file->new_abs( 't/file_upload.html' )->as_string;
+my ($form, $input);
+
+# &field
+
+$mc->get( $uri );
+$mc->field( 'document', [$file, $filename] );
+($form) = $mc->forms;
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/$mc->field( 'document', [$file, $filename] )/ );
+
+$mc->get( $uri );
+$mc->field( 'document', [$file, $filename, Content => 'content'] );
+($form) = $mc->forms;
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/$mc->field( 'document', [$file, $filename, Content => 'content'] )/ );
+
+# &set_fields
+
+$mc->get( $uri );
+$mc->set_fields( 'document' => [ $file, $filename ] );
+($form) = $mc->forms;
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/$mc->set_fields( 'document' => [ $file, $filename ] )/ );
+
+$mc->get( $uri );
+$mc->set_fields( 'document' => [ $file, $filename, Content => 'content' ] );
+($form) = $mc->forms;
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/$mc->set_fields( 'document' => [ $file, $filename, Content => 'content' ] )/ );
+
+$mc->get( $uri );
+$mc->set_fields( 'document' => [[ $file, $filename ], 1] );
+($form) = $mc->forms;
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/$mc->set_fields( 'document' => [[ $file, $filename ], 1] )/ );
+
+$mc->get( $uri );
+$mc->set_fields
+  ( 'document' => [[ $file, $filename, Content => 'content' ], 1] );
+($form) = $mc->forms;
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/$mc->set_fields( 'document' => [[ $file, $filename, Content => 'content' ], 1] )/ );
+
+done_testing;


### PR DESCRIPTION
Hi

I've found some inconsistencies in Mech's processing of fields
of type "file". The data I'm giving to &field and to &set_fields is
not being honored. I'm using them according to &submit_form's
documentation.

These

    $mech->field('document', ['/tmp/file.txt', 'the_file.txt']);
    $mech->set_fields('document' => ['/tmp/file.txt', 'the_file.txt']);

won't produce the expected result, i.e., a HTTP request body that
contains `filename="the_file.txt"`.

I worked on the problem and found out that Mech is using a HTML::Form's
API that has a bug and is considered "legacy" (according to a comment in
HTML::Form's code). This causes problems to Mech.

But Mech's own use of the API also has a bug: when the field type is
"file", Mech is not handling its value correctly.

The attached patch makes Mech use the current API and adds
documentation to &set_fields and &field.

It's worth noting that &set_fields was doing (multiple times) what
&field does, but was not reutilizing &field. The patch fixes this.
