### PR TITLE
fix a POD syntax error

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -3118,7 +3118,7 @@ __END__
 The default settings can get you up and running quickly, but there are settings
 you can change in order to make your life easier.
 
-=over4
+=over 4
 
 =item autocheck
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
WWW-Mechanize.
We thought you might be interested in it too.

    Description: fix a POD syntax error
     POD ERRORS
         Hey! The above document had some coding errors, which are explained
         below:
     .
         Around line 3062:
             Unknown directive: =over4
     .    
         Around line 3064:
             '=item' outside of any '=over'
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-05-07
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libwww-mechanize-perl/raw/master/debian/patches/pod-syntax.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
