### PR TITLE
Fixed pod error as reported by CPANTS.

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -2197,7 +2197,7 @@ fields don't exist on the page, and/or a value doesn't exist in a select element
 By default HTML::Form sets this value to false.
 
 This behavior can also be turned on globally by passing C<< strict_forms => 1 >> to
-C<<WWW::Mechanize->new>>. If you do that, you can still disable it for individual calls
+C<< WWW::Mechanize->new >>. If you do that, you can still disable it for individual calls
 by passing C<< strict_forms => 0 >> here.
 
 =back


### PR DESCRIPTION
Hi @oalders 

Please review the PR.
https://cpants.cpanauthors.org/release/OALDERS/WWW-Mechanize-1.89

As per the document:

           "Doubled angle brackets ("<<" and ">>") may be used if and only if there is whitespace right 
            after the opening delimiter and whitespace right before the closing delimiter!"
  
Many Thanks.
Best Regards,
Mohammad S Anwar 