### PR TITLE
remove PodSyntaxTests

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,8 +19,6 @@ dir = bin
 
 [RunExtraTests]
 
-[PodSyntaxTests]
-
 [Prereqs / RuntimeRequires]
 perl = 5.006
 Scalar::Util = 1.14


### PR DESCRIPTION
* PodSyntaxTests are included by v0.000020 of `@Author::OALDERS` bundle