### PR TITLE
don't install Perl::Critic and Perl::Tidy to run user tests

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -25,11 +25,11 @@ Scalar::Util = 1.14
 
 [Prereqs / TestRequires]
 CGI = 4.32
-Perl::Critic = 0
-Perl::Tidy = 0
 
 [Prereqs / DevelopRequires]
 Code::TidyAll::Plugin::SortLines::Naturally = 0.000003
+Perl::Critic = 0
+Perl::Tidy = 0
 
 [MetaProvides::Package]
 


### PR DESCRIPTION
Fixes #267 