### PR TITLE
Document that follow_link will die on failure with autocheck enabled

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -912,9 +912,11 @@ or
 
 =back
 
-Returns the result of the GET method (an HTTP::Response object) if
-a link was found. If the page has no links, or the specified link
-couldn't be found, returns undef.
+Returns the result of the C<GET> method (an L<HTTP::Response> object) if a link
+was found.
+
+If the page has no links, or the specified link couldn't be found, returns
+C<undef>.  If C<autocheck> is enabled an exception will be thrown instead.
 
 =cut
 


### PR DESCRIPTION
I was bitten by this today.  The docs as they currently are don't even hint at a possible exception when `follow_link` doesn't find what it needs.