### PR TITLE
install LWP::Protocol::https and fix xt/author/live/encoding.t

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
     - RELEASE_TESTING=1
 before_install:
   - eval $(curl https://travis-perl.github.io/init) --auto --always-upgrade-modules
-  - cpanm Test::Memory::Cycle Test::Taint || true
+  - cpanm Test::Memory::Cycle Test::Taint LWP::Protocol::https || true
 ### __app_cisetup__
 # ---
 # force_threaded_perls: 0

--- a/xt/author/live/encoding.t
+++ b/xt/author/live/encoding.t
@@ -2,8 +2,8 @@ use strict;
 use warnings;
 
 use constant PAIRS => {
-    'https://www.tripadvisor.com/'                 => 'utf-8',
-    'http://www.liveinternet.ru/users/dashdi/blog' => 'cp1251',
+    'https://www.tripadvisor.com/'     => 'utf-8',
+    'https://www.liveinternet.ru/top/' => 'cp1251',
 };
 
 use Encode;
@@ -11,7 +11,7 @@ use Test::More;
 use Test::Needs 'LWP::Protocol::https';
 use Test::RequiresInternet(
     'www.tripadvisor.com' => 443,
-    'www.liveinternet.ru' => 80
+    'www.liveinternet.ru' => 443
 );
 use WWW::Mechanize;
 


### PR DESCRIPTION
Perhaps some travis infrastructures have been changed,
now LWP::Protocol::https is not always available. 
See https://travis-ci.org/libwww-perl/WWW-Mechanize/builds/566535262

So we need to install LWP::Protocol::https for tests.

Also now `http://www.liveinternet.ru/users/dashdi/blog` redirects  to `https://www.liveinternet.ru/top/`, so fix the test.