### PR TITLE
set dist trusty for old perls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ addons:
       - aspell
       - aspell-en
 language: perl
+dist: trusty
 perl:
   - blead
   - dev


### PR DESCRIPTION
It seems that the default ubuntu version in travis ci has changed from trusty to xenial.
Then, because old perls for xenial are not available, travis ci is failing with current master branch.

```
❯ for ubuntu_version in 14.04 16.04; do for perl_version in 5.8 5.10 5.12 5.14 5.16 5.18 5.20 5.22 5.24 5.26 5.28 5.30; do printf "ubuntu_version %s, perl_version %4s, http_status %d\n" $ubuntu_version $perl_version $(curl -X HEAD -w '%{http_code}\n' -s https://storage.googleapis.com/travis-ci-language-archives/perl/binaries/ubuntu/$ubuntu_version/x86_64/perl-$perl_version.tar.bz2); done; done
ubuntu_version 14.04, perl_version  5.8, http_status 200
ubuntu_version 14.04, perl_version 5.10, http_status 200
ubuntu_version 14.04, perl_version 5.12, http_status 200
ubuntu_version 14.04, perl_version 5.14, http_status 200
ubuntu_version 14.04, perl_version 5.16, http_status 200
ubuntu_version 14.04, perl_version 5.18, http_status 200
ubuntu_version 14.04, perl_version 5.20, http_status 200
ubuntu_version 14.04, perl_version 5.22, http_status 200
ubuntu_version 14.04, perl_version 5.24, http_status 200
ubuntu_version 14.04, perl_version 5.26, http_status 200
ubuntu_version 14.04, perl_version 5.28, http_status 200
ubuntu_version 14.04, perl_version 5.30, http_status 200
ubuntu_version 16.04, perl_version  5.8, http_status 404
ubuntu_version 16.04, perl_version 5.10, http_status 404
ubuntu_version 16.04, perl_version 5.12, http_status 404
ubuntu_version 16.04, perl_version 5.14, http_status 404
ubuntu_version 16.04, perl_version 5.16, http_status 404
ubuntu_version 16.04, perl_version 5.18, http_status 404
ubuntu_version 16.04, perl_version 5.20, http_status 404
ubuntu_version 16.04, perl_version 5.22, http_status 200
ubuntu_version 16.04, perl_version 5.24, http_status 200
ubuntu_version 16.04, perl_version 5.26, http_status 200
ubuntu_version 16.04, perl_version 5.28, http_status 200
ubuntu_version 16.04, perl_version 5.30, http_status 200
```
Let's use `dist: trusty` for now.

See also https://travis-ci.community/t/failure-with-perl-5-16-5-18-5-20/2458