### PR TITLE
Document that  :content_file names containing "?" need to have it URL encoded: "%3F".

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -427,6 +427,7 @@ appropriately.
 B<NOTE:> Because C<:content_file> causes the page contents to be
 stored in a file instead of the response object, some Mech functions
 that expect it to be there won't work as expected. Use with caution.
+Also local (file:) names containing "?" need to have it URL encoded: "%3F".
 
 =cut
 


### PR DESCRIPTION
Mention local (file:) names containing "?" need to have it URL encoded: "%3F".