### PR TITLE
make xt/author/eol.t pass

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -1318,14 +1318,14 @@ expression. To select the first image with an id that contains "download"
 anywhere in it, use
 
     $mech->find_image( id_regex => qr/download/ );
-    
+
 =item * C<< classs => string >> and C<< class_regex => regex >>
 
 C<class> matches the class attribute of the image against I<string>, which must
 be an exact match. To select an image with the exact class "img-fuid", use
 
     $mech->find_image( class => 'img-fluid' );
-    
+
 To select an image with the class attribute "rounded float-left", use
 
     $mech->find_image( class => 'rounded float-left' );
@@ -1344,7 +1344,7 @@ images that might also have either class "float-left" or "float-right", use
 
 Selecting an image with multiple classes where you do not care about the
 order they appear in the website's source code is not currently supported.
-    
+
 =back
 
 If C<n> is not specified, it defaults to 1.  Therefore, if you don't

--- a/lib/WWW/Mechanize/Examples.pod
+++ b/lib/WWW/Mechanize/Examples.pod
@@ -224,7 +224,7 @@ mailman's web interface.
     # listmod - fast alternative to mailman list interface
     #
     # usage: listmod crew XXXXXXXX
-    # 
+    #
 
     die "usage: $0 <listname> <password>\n" unless @ARGV == 2;
     my ($listname, $password) = @ARGV;
@@ -259,7 +259,7 @@ mailman's web interface.
 
         # show item info
         my $sender = unescape($item);
-        my ($subject) = [$f->find_input("senderbanp-$item")->value_names]->[1] 
+        my ($subject) = [$f->find_input("senderbanp-$item")->value_names]->[1]
             =~ /Subject:\s+(.+?)\s+Size:/g;
 
         # prompt user
@@ -319,13 +319,13 @@ Last I checked, it didn't work because their HTML didn't match, but it's
 still good as sample code.
 
     #!/usr/bin/perl -w
-    
+
     use strict;
-    
+
     use WWW::Mechanize;
     use Getopt::Long;
     use Text::Wrap;
-    
+
     my $match = undef;
     my $random = undef;
     GetOptions(
@@ -510,12 +510,12 @@ with a results page.
     $mech->field('category_id',1); # adjust as needed
     $mech->field('text',$entry->{btext});
     $mech->field('status',2); # publish, or 1 = draft
-    $results = $mech->submit(); 
+    $results = $mech->submit();
 
     # if we're ok with this entry being datestamped "NOW" (no {date} in %entry)
     # we're done. Otherwise, time to be tricksy
     # MT returns a 302 redirect from this form. the redirect itself contains a <body onload=""> handler
-    # which takes the user to an editable version of the form where the create date can be edited	
+    # which takes the user to an editable version of the form where the create date can be edited
     # MT date format of YYYY-MM-DD HH:MI:SS is the only one that won't error out
 
     if ($entry->{date} && $entry->{date} =~ /^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}/) {
@@ -535,11 +535,11 @@ with a results page.
 Randal submitted this bot that walks the despair.com site sucking down
 all the pictures.
 
-    use strict; 
+    use strict;
     $|++;
 
     use WWW::Mechanize;
-    use File::Basename; 
+    use File::Basename;
 
     my $m = WWW::Mechanize->new;
 
@@ -548,12 +548,12 @@ all the pictures.
     my @top_links = @{$m->links};
 
     for my $top_link_num (0..$#top_links) {
-        next unless $top_links[$top_link_num][0] =~ /^http:/; 
+        next unless $top_links[$top_link_num][0] =~ /^http:/;
 
         $m->follow_link( n=>$top_link_num ) or die "can't follow $top_link_num";
 
         print $m->uri, "\n";
-        for my $image (grep m{^http://store4}, map $_->[0], @{$m->links}) { 
+        for my $image (grep m{^http://store4}, map $_->[0], @{$m->links}) {
             my $local = basename $image;
             print " $image...", $m->mirror($image, $local)->message, "\n"
         }

--- a/lib/WWW/Mechanize/FAQ.pod
+++ b/lib/WWW/Mechanize/FAQ.pod
@@ -120,7 +120,7 @@ Use the mech-dump utility, optionally installed with Mechanize.
     GET http://search.cpan.org/search
       query=
       mode=all                        (option)  [*all|module|dist|author]
-      <NONAME>=CPAN Search            (submit) 
+      <NONAME>=CPAN Search            (submit)
 
 =head2 How do I get Mech to handle authentication?
 

--- a/lib/WWW/Mechanize/Link.pm
+++ b/lib/WWW/Mechanize/Link.pm
@@ -74,7 +74,7 @@ Base URL to which the links are relative.
 
 =head2 $link->attrs()
 
-Returns hash ref of all the attributes and attribute values in the tag. 
+Returns hash ref of all the attributes and attribute values in the tag.
 
 =cut
 

--- a/t/find_image.t
+++ b/t/find_image.t
@@ -51,7 +51,7 @@ ok( $mech->success, "Fetched $uri" ) or die q{Can't get test page};
         [ $mech->images ],
         'images() and find_all_images() return the same thing in list context'
     );
-    
+
     my $images     = $mech->images;
     my $all_images = $mech->find_all_images;
     cmp_deeply(

--- a/t/frames.html
+++ b/t/frames.html
@@ -4,9 +4,9 @@
    </head>
 
    <frameset rows="*,*" frameborder="1" framespacing="0" border="1">
-     <frame name="top" src="find_link.html" marginwidth="8" 
+     <frame name="top" src="find_link.html" marginwidth="8"
 marginheight="8" scrolling="auto" frameborder="no">
-       <frame name="bottom" src="google.html" marginwidth="0" 
+       <frame name="bottom" src="google.html" marginwidth="0"
 marginheight="0" scrolling="no" frameborder="no" noresize>
    </frameset>
 

--- a/t/local/LocalServer.pm
+++ b/t/local/LocalServer.pm
@@ -186,7 +186,7 @@ as a string.
 
 sub get_log {
   my ($self) = @_;
-  
+
   my $log = get( $self->get_server_log );
   $self->stop;
   return $log;

--- a/t/local/nonascii.html
+++ b/t/local/nonascii.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html 
+<!DOCTYPE html
      PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
      "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 


### PR DESCRIPTION
Currently `xt/author/eol.t` fails in travis ci.
This PR addresses it.

Note that, instead of this PR, we may set `-remove = Test::EOL` in dist.ini.