### PR TITLE
find links with the rel attribute to get favicons

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for WWW::Mechanize
 
 {{$NEXT}}
+    - add rel filter to find_link (Julien Fiegehenn)
 
 2.00      2020-06-09 19:09:53Z
     - Require LWP::UserAgent 6.45 (GH#302) (Shoichi Kaji)

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -1002,6 +1002,12 @@ in the page.
 
 Matches the name of the link against I<string> or I<regex>, as appropriate.
 
+=item * C<< rel => string >> and C<< rel_regex => regex >>
+
+Matches the rel of the link against I<string> or I<regex>, as appropriate.
+This can be used to find stylesheets, favicons, or links the author of the
+page does not want bots to follow.
+
 =item * C<< id => string >> and C<< id_regex => regex >>
 
 Matches the attribute 'id' of the link against I<string> or
@@ -1063,7 +1069,7 @@ sub find_link {
 
     my $wantall = ( $params{n} eq 'all' );
 
-    $self->_clean_keys( \%params, qr/^(n|(text|url|url_abs|name|tag|id|class)(_regex)?)$/ );
+    $self->_clean_keys( \%params, qr/^(n|(text|url|url_abs|name|tag|id|class|rel)(_regex)?)$/ );
 
     my @links = $self->links or return;
 
@@ -1113,6 +1119,9 @@ sub _match_any_link_params {
     return if defined $p->{id_regex}      && !($link->attrs->{id} && $link->attrs->{id} =~ $p->{id_regex} );
     return if defined $p->{class}         && !($link->attrs->{class} && $link->attrs->{class} eq $p->{class} );
     return if defined $p->{class_regex}   && !($link->attrs->{class} && $link->attrs->{class} =~ $p->{class_regex} );
+
+    return if defined $p->{rel}         && !($link->attrs->{rel} && $link->attrs->{rel} eq $p->{rel} );
+    return if defined $p->{rel_regex}   && !($link->attrs->{rel} && $link->attrs->{rel} =~ $p->{rel_regex} );
 
     # Success: everything that was defined passed.
     return 1;

--- a/t/dump.t
+++ b/t/dump.t
@@ -31,6 +31,7 @@ subtest "dump_links test", sub {
 http://www.drphil.com/
 HTTP://WWW.UPCASE.COM/
 styles.css
+foo.png
 http://blargle.com/
 http://a.cpan.org/
 http://b.cpan.org/

--- a/t/find_link.html
+++ b/t/find_link.html
@@ -5,6 +5,7 @@
         <meta http-equiv="Refresh" content="0; url='http://www.drphil.com/'">
         <META HTTP-EQUIV="REFRESH" CONTENT="0; URL=HTTP://WWW.UPCASE.COM/">
         <link rel="stylesheet" type="text/css" href="styles.css" />
+        <link rel="icon" type="image/png" href="foo.png" />
         <TITLE>Testing the links</TITLE>
     </head>
     <body>

--- a/t/find_link.t
+++ b/t/find_link.t
@@ -156,6 +156,14 @@ isa_ok( $x, 'WWW::Mechanize::Link' );
 is( $x->[0], 'http://www.yahoo.com/', 'Got js url link' );
 is( $x->url, 'http://www.yahoo.com/', 'Got js url link' );
 
+$x = $mech->find_link( rel => 'icon' );
+isa_ok( $x, 'WWW::Mechanize::Link' );
+is( $x->[0], 'foo.png', 'Got icon url link' );
+
+$x = $mech->find_link( rel_regex => qr/sheet/i );
+isa_ok( $x, 'WWW::Mechanize::Link' );
+is( $x->[0], 'styles.css', 'Got stylesheet url link' );
+
 $mech->get( URI::file->new_abs('t/refresh.html') );
 my $link = $mech->find_link( tag => 'meta' );
 is( $link->url, 'http://www.mysite.com/', 'got link from meta tag via tag search' );


### PR DESCRIPTION
I saw https://stackoverflow.com/questions/63906976/find-favicons-in-html-using-perl and figured this is really something we should be able to do. Getting the favicon is a valid use-case, but so is getting all the non-follow links, or finding an author or licence that way. See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel for more details.