### PR TITLE
Don't follow redirects in some tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for WWW::Mechanize
 
 {{$NEXT}}
+    - Don't follow redirects in some tests (GH#326) (Olaf Alders)
 
 2.06      2021-10-25 20:56:12Z
     [DOCUMENTATION]

--- a/t/dump.t
+++ b/t/dump.t
@@ -154,7 +154,7 @@ sub dump_tests {
 
 sub create_mech {
 	my $filepath = shift;
-	my $mech     = WWW::Mechanize->new( cookie_jar => undef );
+	my $mech     = WWW::Mechanize->new( cookie_jar => undef, max_redirect => 0 );
 	isa_ok( $mech, 'WWW::Mechanize' );
 	my $uri = URI::file->new($filepath)->abs(URI::file->cwd)->as_string;
 

--- a/t/dump.t
+++ b/t/dump.t
@@ -2,11 +2,12 @@
 
 use warnings;
 use strict;
+
+use File::Spec ();
+use File::Temp qw( tempdir );
 use Test::More 0.96 tests => 7;
-use Test::Output;
-use URI::file;
-use File::Temp qw/tempdir/;
-use File::Spec;
+use Test::Output qw( stdout_is stdout_like );
+use URI::file ();
 
 BEGIN {
     use_ok( 'WWW::Mechanize' );

--- a/t/find_link-warnings.t
+++ b/t/find_link-warnings.t
@@ -8,7 +8,7 @@ use WWW::Mechanize ();
 
 BEGIN { delete @ENV{ qw( http_proxy HTTP_PROXY PATH IFS CDPATH ENV BASH_ENV) }; }
 
-my $mech = WWW::Mechanize->new( cookie_jar => undef );
+my $mech = WWW::Mechanize->new( cookie_jar => undef, max_redirect => 0 );
 isa_ok( $mech, 'WWW::Mechanize' );
 
 my $uri = URI::file->new_abs( 't/find_link.html' )->as_string;

--- a/t/find_link.t
+++ b/t/find_link.t
@@ -4,7 +4,7 @@ use warnings;
 use strict;
 
 use Test::More;
-use URI::file;
+use URI::file ();
 
 BEGIN {
     delete @ENV{qw(PATH IFS CDPATH ENV BASH_ENV)};  # Placates taint-unsafe Cwd.pm in 5.6.1

--- a/t/find_link.t
+++ b/t/find_link.t
@@ -11,7 +11,7 @@ BEGIN {
     use_ok( 'WWW::Mechanize' );
 }
 
-my $mech = WWW::Mechanize->new( cookie_jar => undef );
+my $mech = WWW::Mechanize->new( cookie_jar => undef, max_redirect => 0 );
 isa_ok( $mech, 'WWW::Mechanize' );
 
 my $uri = URI::file->new_abs( 't/find_link.html' )->as_string;


### PR DESCRIPTION
- Tidy imports in dump.t and find_link.t
- Don't try to follow redirects in tests
