### PR TITLE
Rework of #110 and #69

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cpanfile.snapshot
 tidyall.ERR
 /WWW-Mechanize-*/
 /WWW-Mechanize-*.tar.gz
+/.vscode

--- a/Changes
+++ b/Changes
@@ -2,7 +2,13 @@ Revision history for WWW::Mechanize
 
 {{$NEXT}}
 
+    [ENHANCEMENTS]
+    - form_name(), form_id(), form_with() and form_with_fields() can now all
+      return the nth instance of a form instead of always returning the first
+      instance (GH#110) (Jeff Culverhouse and Julien Fiegehenn)
+
 2.11      2022-07-17 17:25:39Z
+
     [FIXED]
     - tick() can now handle checkboxes without a value (GH#331) (Jordan M Adler
       and Julien Fiegehenn)

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -2028,7 +2028,7 @@ sub select {
 
 =head2 $mech->set_fields( $name => $value ... )
 
-=head2 $mech->set_fields( $name => \@nvalue_and_instance_number )
+=head2 $mech->set_fields( $name => \@value_and_instance_number )
 
 =head2 $mech->set_fields( $name => \$value_instance_number )
 

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -1703,10 +1703,14 @@ sub all_forms_with_fields {
 
 =head2 $mech->form_with_fields( @fields, [$nth] )
 
-Selects a form by passing in a list of field names it must contain.  The nth-match
-wanted may be specified and either that match is returned or undef.  Otherwise,
-if not nth-match is specified, if there is more than one form on the page with that
-matches, then the first one is used, and a warning is generated.
+Selects a form by passing in a list of field names it must contain. More than
+one form could match the fields passed in. By default, the first match will be
+returned, but if you want the 2nd or 3rd or nth match, pass the match # you
+want as the final parameter.
+
+If the nth-match is specified, either that match is returned or undef if not
+found. Otherwise, if nth-match is not specified and more than one form on the
+page matches, then the first one is used, and a warning is generated.
 
 If it is found, the form is returned as an L<HTML::Form> object and set internally
 for later used with Mech's form methods such as
@@ -1780,12 +1784,14 @@ instead.)
 When given more than one pair, all criteria must match.
 Using C<undef> as value means that the attribute in question must not be present.
 
+More than one form could match the criteria passed in. By default, the first match
+will be returned, but if you want the 2nd or 3rd or nth match, pass the match # you
+want with the key 'nth'.
+
 If it is found, the form is returned as an L<HTML::Form> object and set internally
 for later used with Mech's form methods such as
 C<L<< field()|/"$mech->field( $name, $value, $number )" >>> and
 C<L<< click()|/"$mech->click( $button [, $x, $y] )" >>>.
-
-The nth-match to return may be specified with 'nth' attribute.
 
 Returns undef if no form is found.
 

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -1636,11 +1636,14 @@ sub form_action {
     return;
 }
 
-=head2 $mech->form_name( $name )
+=head2 $mech->form_name( $name [, $nth] )
 
-Selects a form by name.  If there is more than one form on the page
-with that name, then the first one is used, and a warning is
-generated.
+Selects a form by name.  More than one form could match the name passed in.
+By default, the first match will be returned, but if you want the 2nd or
+3rd or nth match, pass the match # you want as the final parameter.
+
+If $nth parameter is not passed, and there is more than one form on the page
+with that name, then the first one is used, and a warning is generated.
 
 If it is found, the form is returned as an L<HTML::Form> object and
 set internally for later use with Mech's form methods such as
@@ -1652,13 +1655,17 @@ Returns undef if no form is found.
 =cut
 
 sub form_name {
-    my ($self, $form) = @_;
-    return $self->form_with( name => $form );
+    my ($self, $form, $nth) = @_;
+    return $self->form_with( name => $form, $nth ? ( nth => $nth ) : () );
 }
 
-=head2 $mech->form_id( $id )
+=head2 $mech->form_id( $id [, $nth] )
 
-Selects a form by ID.  If there is more than one form on the page
+Selects a form by ID.  More than one form could match the ID passed in.
+By default, the first match will be returned, but if you want the 2nd or
+3rd or nth match, pass the match # you want as the final parameter.
+
+If $nth parameter is not passed, and there is more than one form on the page
 with that ID, then the first one is used, and a warning is generated.
 
 If it is found, the form is returned as an L<HTML::Form> object and
@@ -1672,8 +1679,8 @@ unless C<quiet> is enabled.
 =cut
 
 sub form_id {
-    my ($self, $formid) = @_;
-    defined( my $form = $self->form_with( id => $formid ) )
+    my ($self, $formid, $nth) = @_;
+    defined( my $form = $self->form_with( id => $formid, $nth ? ( nth => $nth ) : () ) )
       or $self->warn(qq{ There is no form with ID "$formid"});
     return $form;
 }

--- a/t/form_with_fields.t
+++ b/t/form_with_fields.t
@@ -58,13 +58,13 @@ ok( $mech->success, "Fetched $uri" ) or die q{Can't get test page};
 }
 
 {
-    my $form = $mech->form_with_fields('4a', '4b', 1);
+    my $form = $mech->form_with_fields('4a', '4b', { n => 1 });
     isa_ok( $form, 'HTML::Form' );
     is($form->attr('name'), '4th_form_1', 'fourth form match 1 matches');
 }
 
 {
-    my $form = $mech->form_with_fields('4a', '4b', 2);
+    my $form = $mech->form_with_fields('4a', '4b', { n => 2 });
     isa_ok( $form, 'HTML::Form' );
     is($form->attr('name'), '4th_form_2', 'fourth form match 2 matches');
 }
@@ -72,7 +72,7 @@ ok( $mech->success, "Fetched $uri" ) or die q{Can't get test page};
 {
     my $form;
     cmp_deeply(
-        [ warnings { $form = $mech->form_with_fields('4a', '4b', 3) } ],
+        [ warnings { $form = $mech->form_with_fields('4a', '4b', { n => 3 }) } ],
         [ re(qr/There is no match #3 form with the requested fields/) ],
         'warning on unmatched nth form',
     );

--- a/t/form_with_fields.t
+++ b/t/form_with_fields.t
@@ -58,6 +58,28 @@ ok( $mech->success, "Fetched $uri" ) or die q{Can't get test page};
 }
 
 {
+    my $form = $mech->form_with_fields('4a', '4b', 1);
+    isa_ok( $form, 'HTML::Form' );
+    is($form->attr('name'), '4th_form_1', 'fourth form match 1 matches');
+}
+
+{
+    my $form = $mech->form_with_fields('4a', '4b', 2);
+    isa_ok( $form, 'HTML::Form' );
+    is($form->attr('name'), '4th_form_2', 'fourth form match 2 matches');
+}
+
+{
+    my $form;
+    cmp_deeply(
+        [ warnings { $form = $mech->form_with_fields('4a', '4b', 3) } ],
+        [ re(qr/There is no match #3 form with the requested fields/) ],
+        'warning on unmatched nth form',
+    );
+    is( $form, undef, 'undef on unmatched nth form' );
+}
+
+{
     my @forms = $mech->all_forms_with( name => '3rd_form_ambiguous' );
     is( scalar @forms, 2 );
     isa_ok( $forms[0], 'HTML::Form' );

--- a/t/local/failure.t
+++ b/t/local/failure.t
@@ -38,7 +38,7 @@ GOOD_PAGE: {
     my @links = $mech->links;
     is( scalar @links, 10, '10 links, please' );
     my @forms = $mech->forms;
-    is( scalar @forms, 3, 'Many forms' );
+    is( scalar @forms, 5, 'Many form' );
 }
 
 BAD_PAGE: {

--- a/t/local/form.t
+++ b/t/local/form.t
@@ -36,9 +36,30 @@ my $form_name_f = $mech->form_name('f');
 isa_ok( $form_name_f, 'HTML::Form', 'form_name - can select the form' );
 ok( !$mech->form_name('bargle-snark'), 'form_name - cannot select non-existent form' );
 
+$form_name_f = $mech->form_name('mf');
+isa_ok( $form_name_f, 'HTML::Form', 'Can select the form' );
+
+$form_name_f = $mech->form_name('mf', 1);
+isa_ok( $form_name_f, 'HTML::Form', 'Can select the 1st multiform' );
+
+$form_name_f = $mech->form_name('mf', 2);
+isa_ok( $form_name_f, 'HTML::Form', 'Can select the 2nd multiform' );
+ok( !$mech->form_name('mf', 3), 'cannot select non-existent multiform' );
+
 my $form_id_pounder = $mech->form_id('pounder');
+
 isa_ok( $form_id_pounder, 'HTML::Form', 'form_id - can select the form' );
-ok( !$mech->form_id('bargle-snark'), 'form_id - cannot select non-existent form' );
+ok( !$mech->form_id('bargle-snark'), 'form_id - cannot select non-existent multiform' );
+
+$form_id_pounder = $mech->form_id('multiform');
+isa_ok( $form_id_pounder, 'HTML::Form', 'form_id - can select the multiform' );
+
+$form_id_pounder = $mech->form_id('multiform', 1);
+isa_ok( $form_id_pounder, 'HTML::Form', 'v select the 1st multiform' );
+
+$form_id_pounder = $mech->form_id('multiform' ,2);
+isa_ok( $form_id_pounder, 'HTML::Form', 'form_id - can select the 2nd multiform' );
+ok( !$mech->form_id('multiform', 3), 'form_id - cannot select non-existent multiform' );
 
 my $form_with = $mech->form_with( class => 'test', id => undef );
 isa_ok( $form_with, 'HTML::Form', 'form_with - can select the form without id' );

--- a/t/local/form.t
+++ b/t/local/form.t
@@ -6,8 +6,8 @@ use lib 't/local';
 use LocalServer;
 
 BEGIN {
-    delete @ENV{ qw( IFS CDPATH ENV BASH_ENV ) };
-    use_ok( 'WWW::Mechanize' );
+    delete @ENV{qw( IFS CDPATH ENV BASH_ENV )};
+    use_ok('WWW::Mechanize');
 }
 
 my $server = LocalServer->spawn;
@@ -17,63 +17,86 @@ my @warnings;
 my $mech = WWW::Mechanize->new( onwarn => sub { push @warnings, @_ } );
 isa_ok( $mech, 'WWW::Mechanize' ) or die;
 $mech->quiet(1);
-$mech->get($server->url);
+$mech->get( $server->url );
 ok( $mech->success, 'got a page' ) or die;
 is( $mech->uri, $server->url, 'got correct page' );
 
-my ($form, $number) = $mech->form_number(1);
-isa_ok( $form, 'HTML::Form', 'form_number - can select the first form in list context call');
+my ( $form, $number ) = $mech->form_number(1);
+isa_ok( $form, 'HTML::Form',
+    'form_number - can select the first form in list context call' );
 is( $number, 1, 'form_number - form number is correct' );
 
 my $form_number_1 = $mech->form_number(1);
-isa_ok( $form_number_1, 'HTML::Form', 'form_number - can select the first form');
-is( $mech->current_form(), $mech->{forms}->[0], 'form_number - set the form attribute' );
+isa_ok( $form_number_1, 'HTML::Form',
+    'form_number - can select the first form' );
+is(
+    $mech->current_form(),
+    $mech->{forms}->[0],
+    'form_number - set the form attribute'
+);
 
-ok( !$mech->form_number(99), 'form_number - cannot select the 99th form');
-is( $mech->current_form(), $mech->{forms}->[0], 'form_number - form is still set to 1' );
+ok( !$mech->form_number(99), 'form_number - cannot select the 99th form' );
+is(
+    $mech->current_form(),
+    $mech->{forms}->[0],
+    'form_number - form is still set to 1'
+);
 
 my $form_name_f = $mech->form_name('f');
 isa_ok( $form_name_f, 'HTML::Form', 'form_name - can select the form' );
-ok( !$mech->form_name('bargle-snark'), 'form_name - cannot select non-existent form' );
+ok( !$mech->form_name('bargle-snark'),
+    'form_name - cannot select non-existent form' );
 
 $form_name_f = $mech->form_name('mf');
-isa_ok( $form_name_f, 'HTML::Form', 'Can select the form' );
+isa_ok( $form_name_f, 'HTML::Form', 'form_name - can select the form' );
 
-$form_name_f = $mech->form_name('mf', 1);
-isa_ok( $form_name_f, 'HTML::Form', 'Can select the 1st multiform' );
+$form_name_f = $mech->form_name( 'mf', { n => 1 } );
+isa_ok( $form_name_f, 'HTML::Form',
+    'form_name - can select the 1st multiform' );
 
-$form_name_f = $mech->form_name('mf', 2);
-isa_ok( $form_name_f, 'HTML::Form', 'Can select the 2nd multiform' );
-ok( !$mech->form_name('mf', 3), 'cannot select non-existent multiform' );
+$form_name_f = $mech->form_name( 'mf', { n => 2 } );
+isa_ok( $form_name_f, 'HTML::Form',
+    'form_name - can select the 2nd multiform' );
+ok( !$mech->form_name( 'mf', { n => 3 } ),
+    'form_name - cannot select non-existent multiform' );
 
 my $form_id_pounder = $mech->form_id('pounder');
 
 isa_ok( $form_id_pounder, 'HTML::Form', 'form_id - can select the form' );
-ok( !$mech->form_id('bargle-snark'), 'form_id - cannot select non-existent multiform' );
+ok( !$mech->form_id('bargle-snark'),
+    'form_id - cannot select non-existent multiform' );
 
 $form_id_pounder = $mech->form_id('multiform');
 isa_ok( $form_id_pounder, 'HTML::Form', 'form_id - can select the multiform' );
 
-$form_id_pounder = $mech->form_id('multiform', 1);
-isa_ok( $form_id_pounder, 'HTML::Form', 'v select the 1st multiform' );
+$form_id_pounder = $mech->form_id( 'multiform', { n => 1 } );
+isa_ok( $form_id_pounder, 'HTML::Form',
+    'form_id - can select the 1st multiform' );
 
-$form_id_pounder = $mech->form_id('multiform' ,2);
-isa_ok( $form_id_pounder, 'HTML::Form', 'form_id - can select the 2nd multiform' );
-ok( !$mech->form_id('multiform', 3), 'form_id - cannot select non-existent multiform' );
+$form_id_pounder = $mech->form_id( 'multiform', { n => 2 } );
+isa_ok( $form_id_pounder, 'HTML::Form',
+    'form_id - can select the 2nd multiform' );
+ok(
+    !$mech->form_id( 'multiform', { n => 3 } ),
+    'form_id - cannot select non-existent multiform'
+);
 
 my $form_with = $mech->form_with( class => 'test', id => undef );
-isa_ok( $form_with, 'HTML::Form', 'form_with - can select the form without id' );
+isa_ok( $form_with, 'HTML::Form',
+    'form_with - can select the form without id' );
 is( $mech->current_form, $form_number_1,
     'form_with - form without id is now the current form' );
 
 my $form_number_2 = $mech->form_number(2);
-$form_with = $mech->form_with( class => 'test', foo => '', bar => undef, nth => 2 );
+$form_with =
+  $mech->form_with( class => 'test', foo => '', bar => undef, { n => 2 } );
 is( $form_with, $form_number_2, 'Can select nth form with ambiguous criteria' );
 
 is( scalar @warnings, 0, 'no warnings so far' );
 $mech->quiet(0);
 $form_with = $mech->form_with( class => 'test', foo => '', bar => undef );
-is( $form_with, $form_number_1, 'form_with - can select form with ambiguous criteria' );
+is( $form_with, $form_number_1,
+    'form_with - can select form with ambiguous criteria' );
 is( scalar @warnings, 1, 'form_with - got one warning' );
 is(
     "@warnings",
@@ -91,13 +114,12 @@ ok( !$mech->form_action('bargle-snark'),
 $mech->quiet(0);
 my $form_action = $mech->form_action('formsubmit');
 isa_ok( $form_action, 'HTML::Form', 'form_action - can select the form' );
-is( scalar @warnings, 2, 'form_actino - got one warning' );
+is( scalar @warnings, 2, 'form_action - got one warning' );
 like(
     $warnings[-1],
     qr/with action matching/,
     'form_action - got correct multiple-matching-forms warning'
 );
 $mech->quiet(1);
-
 
 done_testing;

--- a/t/local/form.t
+++ b/t/local/form.t
@@ -45,6 +45,10 @@ isa_ok( $form_with, 'HTML::Form', 'form_with - can select the form without id' )
 is( $mech->current_form, $form_number_1,
     'form_with - form without id is now the current form' );
 
+my $form_number_2 = $mech->form_number(2);
+$form_with = $mech->form_with( class => 'test', foo => '', bar => undef, nth => 2 );
+is( $form_with, $form_number_2, 'Can select nth form with ambiguous criteria' );
+
 is( scalar @warnings, 0, 'no warnings so far' );
 $mech->quiet(0);
 $form_with = $mech->form_with( class => 'test', foo => '', bar => undef );

--- a/t/local/log-server
+++ b/t/local/log-server
@@ -188,6 +188,12 @@ __DATA__
   <form id="searchbox" action="/google-cli">
     <input type="text" name="query" value="%s"/>
   </form>
+  <form name="mf" id="multiform" action="/formsubmit" class="test mf1" foo="">
+    <input type="text1" name="query" value="%s"/>
+  </form>
+  <form name="mf" id="multiform" action="/formsubmit" class="test mf2" foo="">
+    <input type="text2" name="query" value="%s"/>
+  </form>
 </p>
 </body>
 </html>


### PR DESCRIPTION
I've taken the work done in #110, added the interface changes suggested by @skaji and amended the tests.

To pick up on the original discussion as to what makes up an HTML `name` attribute:

- `name` can be [CDATA](https://www.w3.org/TR/html401/types.html#type-cdata), which means single whitespaces and any characters. Numbers as names are allowed. See https://www.w3.org/TR/html401/interact/forms.html#adef-name-INPUT 
- `id` can contain any character but whitespace, see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id

Closes #110 
Fixes #69 