### PR TITLE
add test to check links in POD

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,6 +10,8 @@ Revision history for WWW::Mechanize
     [TESTS]
     - Tests using a local temporary server are now safe to use with HTTP/1.1
       and keep-alive (GH #14) (Stanislaw Pusep and Julien Fiegehenn)
+    - We now use Test::Pod::LinkCheck to ensure there are no broken links in
+      our documentation (GH #337) (Julien Fiegehenn)
 
 2.11      2022-07-17 17:25:39Z
 

--- a/cpanfile
+++ b/cpanfile
@@ -78,6 +78,7 @@ on 'develop' => sub {
   requires "Test::Needs" => "0";
   requires "Test::Pod" => "1.41";
   requires "Test::Pod::Coverage" => "1.08";
+  requires "Test::Pod::LinkCheck" => "0";
   requires "Test::Portability::Files" => "0";
   requires "Test::RequiresInternet" => "0";
   requires "Test::Vars" => "0.014";

--- a/dist.ini
+++ b/dist.ini
@@ -20,6 +20,7 @@ StaticInstall.dry_run = 0
 dir = script
 
 [RunExtraTests]
+[Test::Pod::LinkCheck]
 
 [Prereqs / RuntimeRequires]
 perl = 5.006

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -1030,7 +1030,7 @@ sub follow_link {
 Finds a link in the currently fetched page. It returns a
 L<WWW::Mechanize::Link> object which describes the link.  (You'll
 probably be most interested in the
-C<L<< url()|"WWW::Mechanize::Link/$link->url()" >>> property.)
+C<L<< url()|WWW::Mechanize::Link/"$link->url()" >>> property.)
 If it fails to find a link it returns C<undef>.
 
 You can take the URL part and pass it to the C<get()> method.  If
@@ -2423,8 +2423,9 @@ and data setting in one operation. It selects the first form that contains all
 fields mentioned in C<\%fields>.  This is nice because you don't need to know
 the name or number of the form to do this.
 
-(calls C<L<< form_with_fields()|/"$mech->form_with_fields( @fields )" >>> and
-       C<L<< set_fields()|/"$mech->set_fields( $name => $value ... )" >>>).
+(calls
+C<L<< form_with_fields()|/"$mech->form_with_fields( @fields, [ \%args ] )" >>>
+and C<L<< set_fields()|/"$mech->set_fields( $name => $value ... )" >>>).
 
 If you choose C<with_fields>, the C<fields> option will be ignored. The
 C<form_number>, C<form_name> and C<form_id> options will still be used.  An

--- a/lib/WWW/Mechanize/Cookbook.pod
+++ b/lib/WWW/Mechanize/Cookbook.pod
@@ -7,7 +7,7 @@ First, please note that many of these are possible just using
 L<LWP::UserAgent>.  Since C<WWW::Mechanize> is a subclass of
 L<LWP::UserAgent>, whatever works on C<LWP::UserAgent> should work
 on C<WWW::Mechanize>.  See the L<lwpcook> man page included with
-the L<libwww-perl> distribution.
+L<LWP>.
 
 =head1 BASICS
 

--- a/lib/WWW/Mechanize/FAQ.pod
+++ b/lib/WWW/Mechanize/FAQ.pod
@@ -84,7 +84,7 @@ can be used to add the headers that you need.
 
 =head2 Which modules work like Mechanize and have JavaScript support?
 
-In no particular order: L<Gtk2::WebKit::Mechanize>, L<Win32::IE::Mechanize>,
+In no particular order: L<Gtk2::WebKit::Mechanize>,
 L<WWW::Mechanize::Firefox>, L<WWW::Mechanize::Chrome>, L<WWW::Scripter>,
 L<WWW::Selenium>
 


### PR DESCRIPTION
I just discovered this module. There's actually a Test::Pod::LinkCheck::Lite as well, which has fewer dependencies and doesn't shell out as much, but it does not currently have a dzil package. If we think this generally a good idea and want to introduce these tests to all of our dists, and we feel the ::Lite is better suited, I am happy to make the dzil package.

Happy to hear your thoughts.

I will leave this as draft because it will conflict with the other PRs and I would like to hear opinions first.