### PR TITLE
make mech-dump treat local files as HTML and add more test coverage

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,9 @@ Revision history for WWW::Mechanize
     [FIXED]
     - tick() can now handle checkboxes without a value (GH#331) (Jordan M Adler
       and Julien Fiegehenn)
+    [ENHANCEMENTS]
+    - mech_dump now treats all local files like HTML regardless of what it
+      thinks their content types are (GH#63) (Julien Fiegehenn)
 
 2.10      2022-07-04 21:06:13Z
 

--- a/script/mech-dump
+++ b/script/mech-dump
@@ -72,6 +72,10 @@ Options:
 The order of the options specified is relevant.  Repeated options
 get repeated dumps.
 
+C<mech-dump> will only work on HTML documents when used on remote URLs, but
+will assume any local file you pass it is HTML. If it is not, there won't be
+any usable results.
+
 Proxy settings are specified through the environment (e.g. C<http_proxy=http://proxy.my.place/>).
 See L<LWP::UserAgent> for details.
 
@@ -101,9 +105,11 @@ else {
 
 $mech->env_proxy();
 foreach my $uri (@uris) {
+  my $no_ct_check;
   if ( -e $uri ) {
       require URI::file;
       $uri = URI::file->new_abs( $uri )->as_string;
+      $no_ct_check = 1; # we don't have to check the content type
   }
 
   my $response = $mech->get( $uri );
@@ -115,7 +121,10 @@ foreach my $uri (@uris) {
       $response = $mech->get( $uri );
       $response->is_success or die "Can't fetch $uri with username and password\n", $response->status_line, "\n";
   }
-  $mech->is_html or die qq{$uri returns type "}, $mech->ct, qq{", not "text/html"\n};
+
+  unless ($no_ct_check) {
+      $mech->is_html or die qq{$uri returns type "}, $mech->ct, qq{", not "text/html"\n};
+  }
 
   foreach my $action (@actions ) {
       $action->( $mech );

--- a/t/html_file.txt
+++ b/t/html_file.txt
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <form name="text-form" action="http://localhost">
+            <input type="text" name="one" />
+        </form>
+    </body>
+</html>

--- a/t/mech-dump/mech-dump.t
+++ b/t/mech-dump/mech-dump.t
@@ -21,7 +21,7 @@ if ( $^O eq 'VMS' ) {
 
 # Simply use a file: uri instead of the filename to make this test
 # more independent of what URI::* thinks.
-my $source = 'file:t/google.html t/find_inputs.html';
+my $source = 'file:t/google.html t/find_inputs.html t/html_file.txt';
 
 my $perl;
 $perl = $1 if $^X =~ /^(.+)$/;
@@ -57,6 +57,9 @@ POST http://localhost/ [3rd_form]
   YourSister=                    (text)
   YourSister=                    (text)
   submit=Submit                  (submit)
+
+GET http://localhost [text-form]
+  one=                           (text)
 EOF
 } else {
     $expected = <<'EOF';
@@ -85,6 +88,9 @@ POST http://localhost/ [3rd_form]
   YourSister=                    (text)
   YourSister=                    (text)
   submit=Submit                  (submit)
+
+GET http://localhost [text-form]
+  one=                           (text)
 EOF
 }
 

--- a/t/mech-dump/mech-dump.t
+++ b/t/mech-dump/mech-dump.t
@@ -25,7 +25,7 @@ my $source = 'file:t/google.html t/find_inputs.html t/html_file.txt';
 
 my $perl;
 $perl = $1 if $^X =~ /^(.+)$/;
-my $command = "$perl -Ilib $exe --forms $source";
+my $command = "$perl -Ilib $exe --forms --images --links $source";
 
 my $actual = `$command`;
 
@@ -39,6 +39,23 @@ GET file:/target-page [bob-the-form]
   q=
   btnG=Google Search              (submit)
   btnI=I'm Feeling Lucky          (submit)
+
+
+/images/logo.gif
+
+
+/imghp?hl=en&tab=wi&ie=UTF-8
+/grphp?hl=en&tab=wg&ie=UTF-8
+/dirhp?hl=en&tab=wd&ie=UTF-8
+/nwshp?hl=en&tab=wn&ie=UTF-8
+/advanced_search?hl=en
+/preferences?hl=en
+/language_tools?hl=en
+/tour/services/query.html
+/ads/
+/services/
+/options/
+/about.html
 
 POST http://localhost/ (multipart/form-data) [1st_form]
   1a=                            (text)
@@ -70,6 +87,23 @@ GET file:/target-page [bob-the-form]
   q=                             (text)
   btnG=Google Search             (submit)
   btnI=I'm Feeling Lucky         (submit)
+
+
+/images/logo.gif
+
+
+/imghp?hl=en&tab=wi&ie=UTF-8
+/grphp?hl=en&tab=wg&ie=UTF-8
+/dirhp?hl=en&tab=wd&ie=UTF-8
+/nwshp?hl=en&tab=wn&ie=UTF-8
+/advanced_search?hl=en
+/preferences?hl=en
+/language_tools?hl=en
+/tour/services/query.html
+/ads/
+/services/
+/options/
+/about.html
 
 POST http://localhost/ (multipart/form-data) [1st_form]
   1a=                            (text)


### PR DESCRIPTION
I've reimplemented #102 with the most recent suggestion in #63. Closes #102 and fixes #63.