### PR TITLE
fix typo in cpanm command

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -168,4 +168,4 @@ jobs:
         with:
           cpanfile: "cpanfile"
           args: "--with-suggests --with-test --with-develop"
-      - run: cpanm --testonly -v .
+      - run: cpanm --test-only -v .


### PR DESCRIPTION
I noticed this while investigating #343. 