### PR TITLE
run test that captures STDERR without taint mode #350

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for WWW::Mechanize
 
 {{$NEXT}}
+    [FIXED]
+    - There was a test suite failure on some Windows machines introduced in
+      2.14 that is now fixed. (GH#350) (Julien Fiegehenn)
     [ENHANCEMENTS]
     - form_with and all_forms_with() now support the "action" attribute to find
       forms (GH#349) (Julien Fiegehenn)

--- a/t/mech-dump/file_not_found.t
+++ b/t/mech-dump/file_not_found.t
@@ -1,0 +1,40 @@
+#!perl
+
+use warnings;
+use strict;
+
+use Test::More;
+use Test::Output qw(output_like);
+use File::Spec   ();
+
+# See https://stackoverflow.com/a/32054866/1331451
+plan skip_all =>
+    'capturing output from system() is broken in 5.14 and 5.16 on Windows'
+    if $^O eq 'MSWin32' && ( $] >= 5.014 && $] < 5.017 );
+
+plan skip_all => 'Not installing mech-dump'
+    if -e File::Spec->catfile(qw( t SKIP-MECH-DUMP ));
+
+my $exe = File::Spec->catfile(qw( script mech-dump ));
+if ( $^O eq 'VMS' ) {
+  $exe = qq[mcr $^X -Ilib $exe];
+}
+
+my $perl;
+$perl = $1 if $^X =~ /^(.+)$/;
+
+# The following file should not exist.
+my $source = 'file:not_found.404';
+
+my $command = "$perl -Ilib $exe $source";
+
+output_like(
+    sub {
+        system $command;
+    },
+    undef,
+    qr/file:not_found.404 returns status 404/,
+    'Errors when a local file is not found'
+);
+
+done_testing;

--- a/t/mech-dump/mech-dump.t
+++ b/t/mech-dump/mech-dump.t
@@ -4,7 +4,6 @@ use warnings;
 use strict;
 
 use Test::More;
-use Test::Output qw( output_like );
 use File::Spec   ();
 use LWP          ();
 
@@ -147,27 +146,6 @@ EOF
   cmp_ok( @actual,   '>', 0, 'Still some actual' );
 
   is_deeply( \@actual, \@expected, 'Rest of the lines match' );
-};
-
-subtest 'Local file not found' => sub {
-  SKIP: {
-    # See https://stackoverflow.com/a/32054866/1331451
-    skip 'capturing output from system() is broken in 5.14 and 5.16 on Windows', 1
-      if $^O eq 'MSWin32' && ( $] >= 5.014 && $] < 5.017 );
-
-  # The following file should not exist.
-  my $source = 'file:not_found.404';
-
-  my $command = "$perl -Ilib $exe $source";
-
-  output_like(
-    sub {
-      system $command;
-    },
-    undef,
-    qr/file:not_found.404 returns status 404/,
-    'Errors when a local file is not found' );
-  };
 };
 
 done_testing;


### PR DESCRIPTION
It seems that on certain Windows versions File::Temp is not working
properly when run under taint mode. This problem must have been around
for a while. Test::Output uses File::Temp, and therefore runs into this
problem as our mech-dump.t has had the -T flag enabled. I do not know
why we run under taint for some tests, but I have decided the most
pragmatic fix is to undo my previous changes from #292 to the test an to
move this particular test into its own file, which can run without
taint.

Also see https://www.perlmonks.org/?node_id=1122816 for details on the
original problem.

Closes #350.