### PR TITLE
Clarify documentation for the encoding of content_file

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -442,6 +442,11 @@ L<LWP::UserAgent>.  This lets you do things like
 and you can rest assured that the params will get filtered down
 appropriately. See L<LWP::UserAgent/get> for more details.
 
+B<NOTE:> The file in C<:content_file> will contain the raw content of
+the response. If the response content is encoded (e.g. gzip encoded),
+the file will be encoded as well. Use $mech->save_content if you need
+the decoded content.
+
 B<NOTE:> Because C<:content_file> causes the page contents to be
 stored in a file instead of the response object, some Mech functions
 that expect it to be there won't work as expected. Use with caution.


### PR DESCRIPTION
Currently, content_file contains the encoded version of a web response. This causes the `$mech->content()` method and the `:content_file`  to have different encodings. Given that the majority of the web is using compression, it appears that most users would want to use  `$mech->content()` or `$mech->save_content()` instead of `:content_file`. More importantly, this difference should be noted since the word "content" in either case is not clearly specified as encoded or decoded.