### PR TITLE
Fix minor typo in SYNOPSIS example code comment

### DIFF
--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -34,7 +34,7 @@ be queried and revisited.
         button    => 'Search Now'
     );
 
-    # Enable strict form processing to catch typos and non-existant form fields.
+    # Enable strict form processing to catch typos and non-existent form fields.
     my $strict_mech = WWW::Mechanize->new( strict_forms => 1);
 
     $strict_mech->get( $url );


### PR DESCRIPTION
Spotted this while reading through the docs today.

BTW: because this typo occurred in a sentence which also talked about typos, I'm assuming that this wasn't a meta-joke of some kind that I'm missing.

This PR is submitted in the hope that it is useful. If you want anything changed, please don't hesitate to contact me and I'll update it and resubmit as necessary.