### PR TITLE
Warn on the unscoped two-argument credentials() form

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for WWW::Mechanize
 
 {{$NEXT}}
+    [ENHANCEMENTS]
+    - credentials() now warns when called with the two-argument form, which
+      stores credentials globally; prefer the host-scoped four-argument form.
 
 2.21      2026-06-13 07:53:14Z
     [FIXED]

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -3019,6 +3019,11 @@ sub clone {
     $clone->cookie_jar( $self->cookie_jar );
     $clone->{headers} = { %{ $self->{headers} } };
 
+    # SUPER::clone() copies the whole object hash, including the one-shot
+    # warning flag. A clone is a distinct object with its own credentials,
+    # so let it warn once on its own two-argument credentials() call.
+    delete $clone->{__credentials_unscoped_warned};
+
     return $clone;
 }
 
@@ -3127,6 +3132,13 @@ notice.
 
 The four argument form described in L<LWP::UserAgent> is still supported.
 
+B<Security note:> The two-argument form is not scoped to a host. The credentials are stored on the
+object and sent to every host this object contacts, including the targets of cross-domain
+redirects. When the same object may contact more than one host, prefer the host-scoped
+four-argument form C<< $mech->credentials($host_port, $realm, $username, $password) >> described in
+L<LWP::UserAgent>, which limits the credentials to a single host. The two-argument form emits a
+warning on first use.
+
 =cut
 
 sub credentials {
@@ -3140,6 +3152,18 @@ sub credentials {
 
     @_ == 2
         or $self->die('Invalid # of args for overridden credentials()');
+
+    # The two-argument form is unscoped: credentials are stored on the
+    # object and get_basic_credentials() returns them for any host and
+    # realm, so they are sent to every host this object contacts,
+    # including cross-domain redirect targets. Warn once per instance so
+    # callers can move to the host-scoped four-argument form.
+    unless ( $self->{__credentials_unscoped_warned} ) {
+        $self->warn(
+            'WWW::Mechanize: the two-argument credentials() form stores credentials on the object and sends them to every host this object contacts, including cross-domain redirect targets. Use the host-scoped four-argument form credentials($host_port, $realm, $user, $pass) to limit credentials to a specific host.'
+        );
+        $self->{__credentials_unscoped_warned} = 1;
+    }
 
     return @$self{qw( __username __password )} = @_;
 }

--- a/lib/WWW/Mechanize/Cookbook.pod
+++ b/lib/WWW/Mechanize/Cookbook.pod
@@ -43,6 +43,9 @@ Generally, just call C<credentials> before fetching the page.
     $mech->get( 'http://10.11.12.13/password.html' );
     print $mech->content();
 
+If this object may contact more than one host, scope the credentials to a single host with the
+four-argument form; see L<WWW::Mechanize/"$mech-E<gt>credentials( $username, $password )">.
+
 =head1 LINKS
 
 =head2 Find all image links

--- a/t/credentials-api.t
+++ b/t/credentials-api.t
@@ -1,18 +1,15 @@
 use strict;
 use warnings;
 
-use Test::More tests => 4;
+use Test::More;
+use Test::Warnings qw( :no_end_test warnings );
 use LWP::UserAgent ();
 use WWW::Mechanize ();
 use URI            ();
 
-=pod
-
-The monkeypatch introduced since at least WWW::Mechanize 1.34 only
-ever allows one instance of every LWP::UserAgent descendant to have
-credentials.  This test checks that this buggy behaviour is gone.
-
-=cut
+# The monkeypatch introduced since at least WWW::Mechanize 1.34 only
+# ever allows one instance of every LWP::UserAgent descendant to have
+# credentials.  This test checks that this buggy behaviour is gone.
 
 my $uri   = URI->new('http://localhost');
 my $realm = 'myrealm';
@@ -24,8 +21,15 @@ my $mech1 = WWW::Mechanize->new();
 my $mech2 = WWW::Mechanize->new();
 my $mech3 = WWW::Mechanize->new();
 
-$mech1->credentials( 'mech1', 'mech1' );
-$mech2->credentials( 'mech2', 'mech2' );
+my @warnings = warnings {
+    $mech1->credentials( 'mech1', 'mech1' );
+    $mech1->credentials( 'mech1', 'mech1' );
+    $mech2->credentials( 'mech2', 'mech2' );
+    $mech2->credentials( 'mech2', 'mech2' );
+};
+
+is scalar @warnings, 2,
+    'two-argument credentials() warns once per instance';
 
 is_deeply(
     [ $ua->credentials( $uri, $realm ) ], [ 'user', 'pass' ],
@@ -44,3 +48,5 @@ is_deeply(
     [ $mech3->get_basic_credentials( $realm, $uri ) ], [],
     'Untouched instance retains its credentials'
 );
+
+done_testing;

--- a/t/credentials-unscoped-warning.t
+++ b/t/credentials-unscoped-warning.t
@@ -1,0 +1,53 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Warnings qw( :no_end_test warnings );
+use WWW::Mechanize ();
+
+subtest 'two-argument form warns once per instance' => sub {
+    my $mech = WWW::Mechanize->new;
+
+    my @warnings = warnings { $mech->credentials( 'user', 'pass' ) };
+    is scalar @warnings, 1,
+        'two-argument credentials() warns on first use';
+    like $warnings[0], qr/four-argument form/,
+        'warning points at the host-scoped four-argument form';
+
+    @warnings = warnings { $mech->credentials( 'user2', 'pass2' ) };
+    is scalar @warnings, 0,
+        'two-argument credentials() warns only once per instance';
+};
+
+subtest 'a clone warns on its own credentials (flag is not inherited)' =>
+    sub {
+    my $mech = WWW::Mechanize->new;
+    warnings { $mech->credentials( 'user', 'pass' ) };
+
+    my $clone    = $mech->clone;
+    my @warnings = warnings {
+        $clone->credentials( 'cloneuser', 'clonepass' )
+    };
+    is scalar @warnings, 1,
+        'a clone warns once on its own two-argument credentials() call';
+    };
+
+subtest 'host-scoped forms do not warn' => sub {
+    my $mech = WWW::Mechanize->new;
+
+    my @warnings = warnings {
+        $mech->credentials( 'localhost:80', 'realm', 'user', 'pass' )
+    };
+    is scalar @warnings, 0,
+        'four-argument credentials() does not warn';
+
+    @warnings = warnings {
+        $mech->credentials( 'localhost:80', 'realm' )
+    };
+    is scalar @warnings, 0,
+        'two-argument host:port credentials() does not warn';
+};
+
+done_testing;

--- a/t/credentials.t
+++ b/t/credentials.t
@@ -5,10 +5,10 @@ use strict;
 
 use WWW::Mechanize ();
 use Test::More;
-use Test::Fatal qw( exception );
+use Test::Fatal    qw( exception );
+use Test::Warnings qw( :no_end_test warning );
 
 my $mech = WWW::Mechanize->new;
-isa_ok( $mech, 'WWW::Mechanize' );
 
 my ( $user, $pass );
 
@@ -20,13 +20,17 @@ is $pass, undef, 'default password is undefined at first';
 
 like(
     exception {
-        $mech->credentials( "one", "two", "three" );
+        $mech->credentials( 'one', 'two', 'three' );
     },
     qr/Invalid # of args for overridden credentials/,
     'credentials dies with wrong number of args'
 );
 
-$mech->credentials( "username", "password" );
+like(
+    warning { $mech->credentials( 'username', 'password' ) },
+    qr/four-argument form/,
+    'two-argument credentials() warns about host scoping'
+);
 
 ( $user, $pass ) = $mech->get_basic_credentials( 'myrealm', $uri, 0 );
 is $user, 'username',
@@ -43,7 +47,6 @@ is $pass, 'password',
     'cloned object has password for get_basic_credentials';
 
 my $mech3 = WWW::Mechanize->new;
-isa_ok( $mech3, 'WWW::Mechanize' );
 
 ( $user, $pass ) = $mech3->get_basic_credentials( 'myrealm', $uri, 0 );
 is $user, undef, 'new object has no username for get_basic_credentials';


### PR DESCRIPTION
## Summary

The two-argument form `$mech->credentials($username, $password)` stores the
credentials on the Mechanize object and returns them from
`get_basic_credentials()` for *any* host and realm. As a result those
credentials are sent to every host the object subsequently contacts,
including the targets of cross-domain redirects. The four-argument form
`$mech->credentials($host_port, $realm, $username, $password)` is correctly
host-scoped (it delegates to `LWP::UserAgent`).

This is a non-breaking change: behaviour is unchanged. The two-argument form
now emits a one-shot `Carp::carp` warning per instance directing callers to
the host-scoped four-argument form.

## Changes

- `credentials()` warns once per instance when called with the unscoped
  two-argument form.
- `clone()` resets the one-shot flag so a clone warns on its own credentials.
- POD on `credentials()` documents the host-scoping behaviour; the Cookbook
  recipe points at the scoped form.
- Existing credential tests silence the now-expected warning; a new test
  covers the warn-once behaviour and that the scoped forms do not warn.

## Testing

`prove -Ilib t/credentials.t t/credentials-api.t t/credentials-unscoped-warning.t` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
