### PR TITLE
Add App::perlimports and App::perlvars to develop prereqs

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -56,6 +56,8 @@ on 'configure' => sub {
 };
 
 on 'develop' => sub {
+  requires "App::perlimports" => "0";
+  requires "App::perlvars" => "0";
   requires "Code::TidyAll" => "0.71";
   requires "Code::TidyAll::Plugin::SortLines::Naturally" => "0.000003";
   requires "Code::TidyAll::Plugin::Test::Vars" => "0.04";

--- a/dist.ini
+++ b/dist.ini
@@ -31,6 +31,8 @@ HTTP::Message = 7.01
 HTTP::Daemon = 6.12
 
 [Prereqs / DevelopRequires]
+App::perlimports = 0
+App::perlvars = 0
 LWP::Protocol::https = 6.07
 Perl::Critic = 0
 Perl::Tidy = 0


### PR DESCRIPTION
## Summary

The `lint` job runs `perlimports` and `perlvars` (via `precious`), but neither
tool was listed in `DevelopRequires`. As a result `cpan-install-dist-deps
--with-develop` never installed them, and the lint job fails on every file
with:

```
Lint command "perlimports" failed to execute: Could not find "perlimports" in your path
Lint command "perlvars"   failed to execute: Could not find "perlvars" in your path
```

This currently fails on `master` as well, independent of any code change.

## Fix

Add `App::perlimports` and `App::perlvars` to `[Prereqs / DevelopRequires]` in
`dist.ini` (and the generated `cpanfile`) so the lint job installs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
