### PR TITLE
Fix: Referer and HEAD using WWW::Mechanize (GH#150)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Revision history for WWW::Mechanize
 
 {{$NEXT}}
+    [FIXED]
+    - Non-navigational requests (HEAD, PUT, DELETE) no longer set the Referer
+      header sent on subsequent requests. Previously a head() call would leak
+      its URL as the Referer of the next get(), even after back() (GH#150)
+      (Olaf Alders)
 
 2.21      2026-06-13 07:53:14Z
     [FIXED]

--- a/lib/WWW/Mechanize.pm
+++ b/lib/WWW/Mechanize.pm
@@ -3225,8 +3225,16 @@ sub _update_page {
     $self->{ct}     = $res->content_type || q{};
 
     if ( $res->is_success ) {
-        $self->{uri}      = $self->{redirected_uri};
-        $self->{last_uri} = $self->{uri};
+        $self->{uri} = $self->{redirected_uri};
+
+        # Only navigational requests (GET/POST) update the URI that gets
+        # sent as the Referer on subsequent requests. A HEAD (or PUT/DELETE)
+        # does not change the page you are "on", so it must not clobber the
+        # Referer. This mirrors the condition that gates the page stack in
+        # request(). See GH #150.
+        if ( $request->method eq 'GET' || $request->method eq 'POST' ) {
+            $self->{last_uri} = $self->{uri};
+        }
     }
 
     if ( $res->is_error ) {

--- a/t/local/referer-server
+++ b/t/local/referer-server
@@ -7,7 +7,10 @@ $|++;
 my $d = HTTP::Daemon->new or die;
 print $d->url, "\n";
 
-$counter = 6;
+# Upper bound on the number of client connections to accept before the
+# server exits. Must be at least as large as the number of HTTP requests
+# referer.t makes (back() makes none); over-provisioning is harmless.
+$counter = 10;
 while ( $counter-- and my $c = $d->accept ) {
     while ( my $r = $c->get_request ) {
         my $location = ( $r->uri->path || "/" );

--- a/t/local/referer.t
+++ b/t/local/referer.t
@@ -2,7 +2,7 @@ use warnings;
 use strict;
 use FindBin ();
 
-use Test::More tests => 14;
+use Test::More;
 
 use Test::Memory::Cycle;
 
@@ -51,6 +51,25 @@ SKIP: {
         'Referer got sent for relative url'
     );
 
+    # GH #150: a HEAD (or other non-navigational) request must not become
+    # the Referer for the next request. Issue the HEAD against a distinct
+    # path so a regression would show that path as the Referer.
+    $agent->head( $url . 'headcheck' );
+    $agent->get($url);
+    is(
+        $agent->content, "Referer: '$url'",
+        'HEAD does not clobber the Referer for the next request'
+    );
+
+    # ...and it stays correct across a back().
+    $agent->head( $url . 'headcheck' );
+    $agent->back();
+    $agent->get($url);
+    is(
+        $agent->content, "Referer: '$url'",
+        'HEAD does not clobber the Referer even after back()'
+    );
+
     $agent->add_header( Referer => 'x' );
     $agent->get($url);
     is( $agent->status, 200, 'Got fourth page' ) or diag $agent->res->message;
@@ -70,6 +89,8 @@ SKIP: {
 }
 
 memory_cycle_ok( $agent, 'No memory cycles found' );
+
+done_testing;
 
 END {
     close $server if $server;


### PR DESCRIPTION
Closes #150

## Problem

A `$mech->head($url)` request leaked its URL as the `Referer` header on subsequent `get()` requests, even after calling `back()`.

`_update_page()` set `$self->{last_uri}` for **every** successful response, and `last_uri` is the sole source of the `Referer` header in `_modify_request()`. Because a HEAD request does not push the page stack, a following `back()` had nothing to pop, so the HEAD URL persisted as `last_uri` and leaked as the `Referer` of the next request.

## Changes

- `lib/WWW/Mechanize.pm`: gate the `last_uri` update in `_update_page()` on the request being `GET` or `POST` — the same condition `request()` uses to decide whether to push the page stack. Non-navigational requests (`HEAD`/`PUT`/`DELETE`) no longer affect the `Referer` sent on subsequent requests.
- `t/local/referer.t`: add coverage that a HEAD does not clobber the `Referer` of the next request, including the `back()` case called out in the issue. Converted the fixed `tests => N` plan to `done_testing`.
- `t/local/referer-server`: raise the connection ceiling to cover the new requests, with an explanatory comment.
- `Changes`: note the fix.

## Testing

- New regression tests fail without the fix and pass with it (red-green verified).
- Full `t/local/` suite passes (322 tests).
- Edited `.pm`/`.t` files pass `perltidy --assert-tidy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)