### PR TITLE
Fix precious lint in merge_group CI events

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,11 +70,11 @@ jobs:
             houseabsolute/precious
       - name: precious lint
         run: |
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            precious lint -q --all
-          else
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
             git fetch origin master:refs/remotes/origin/master
             precious lint -q --git-diff-from origin/${{ github.base_ref }}
+          else
+            precious lint -q --all
           fi
   http-one-one-regression-job:
     name: HTTP/1.1 Keepalive Regression Test - see GH \# 14


### PR DESCRIPTION
## Problem

The `lint` job failed in a merge-queue run ([run 27788351175](https://github.com/libwww-perl/WWW-Mechanize/actions/runs/27788351175/job/82230724897)) — not because of any code style issue (lint passes clean with `--all`), but because of the workflow's branching logic:

```sh
if [ "${{ github.ref }}" = "refs/heads/master" ]; then
  precious lint -q --all
else
  precious lint -q --git-diff-from origin/${{ github.base_ref }}
fi
```

`github.base_ref` is only populated for `pull_request` events. In a `merge_group` event the ref is `refs/heads/gh-readonly-queue/master/pr-...` (so the `master` arm doesn't match) and `base_ref` is empty, so the step ran `precious lint --git-diff-from origin/`, which invoked `git diff ... origin/...` and died with exit 128:

```
fatal: ambiguous argument 'origin/': unknown revision or path not in the working tree.
```

## Fix

Gate on `github.event_name` instead of `github.ref`: only true pull requests use the incremental diff path; merge-queue and master pushes lint the whole tree with `--all`.

## Related

Filed oalders/kitchen-sink#25 so the CI skill that generates this workflow shape emits the event-gated pattern by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)